### PR TITLE
chore: should use find_package for pthread for portability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ find_package(DtkWidget REQUIRED)
 find_package(DtkCMake  REQUIRED)
 find_package(DtkCore REQUIRED)
 find_package(KF5Wayland REQUIRED)
+find_package(Threads REQUIRED)
 find_package(Qt5 COMPONENTS
     Core
     Widgets
@@ -151,7 +152,7 @@ set(LOCK_SRCS
 )
 
 link_libraries(
-    pthread
+    Threads::Threads
 )
 
 add_executable(dde-lock


### PR DESCRIPTION
应当使用 find_package 和 Threads::Threads 来链 pthread 以提高可移植性

注：也应当尽可能避免使用 `link_libraries()`，此处暂不做修改。