### PR TITLE
chore: build on newer debian release

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -42,7 +42,7 @@ Depends: ${shlibs:Depends}, ${misc:Depends}, ${dist:Depends},
  deepin-authenticate(>=1.2.27),
  xsettingsd,
  libssl-dev,
- libxcb-util0
+ libxcb-util0 | libxcb-util1
 Provides: lightdm-greeter
 Recommends: onboard,
  dss-network-plugin,


### PR DESCRIPTION
更新依赖描述（`libxcb-util0` -> `libxcb-util1`），使可以在新版 debian 中顺利构建。（注：在 v20 停止支持后，可考虑移除 libxcb-util0 依赖）

是处理 https://github.com/linuxdeepin/developer-center/issues/3230 问题的一部分。