### PR TITLE
fix: 修复待机休眠已经登录成功插件页面还未初始化的问题

### DIFF
--- a/plugins/one-key-login/login_module.cpp
+++ b/plugins/one-key-login/login_module.cpp
@@ -335,7 +335,8 @@ void LoginModule::slotPrepareForSleep(bool active)
     } else {
        m_isAcceptFingerprintSignal = false;
        startCallHuaweiFingerprint();
-       m_spinner->start();
+       if(m_spinner)
+           m_spinner->start();
        m_waitAcceptSignalTimer->start();
     }
 }


### PR DESCRIPTION
将认证和初始化连接放到initui后面

Log: 修复待机休眠已经登录成功插件页面还未初始化的问题
Task: https://pms.uniontech.com/task-view-176357.html
Influence: 插件登录