### PR TITLE
fix: 一键登录插件崩溃

### DIFF
--- a/plugins/one-key-login/login_module.cpp
+++ b/plugins/one-key-login/login_module.cpp
@@ -49,7 +49,7 @@ LoginModule::LoginModule(QObject *parent)
     , m_loadPluginType(Notload)
     , m_isAcceptFingerprintSignal(false)
     , m_waitAcceptSignalTimer(nullptr)
-    , m_dconfig(DConfig::create(getDefaultConfigFileName(), getDefaultConfigFileName(), QString(), this))
+    , m_dconfig(nullptr)
     , m_spinner(nullptr)
     , m_acceptSleepSignal(false)
     , m_authStatus(AuthStatus::None)
@@ -57,6 +57,10 @@ LoginModule::LoginModule(QObject *parent)
 {
     setObjectName(QStringLiteral("LoginModule"));
 
+    const bool isLock = qApp->applicationName().toLower().contains("lock");
+    qDebug() << "Is lock application: " << isLock << ", application name: "<< qApp->applicationName();
+    const QString &dconfigFile = isLock ? "org.deepin.dde.lock" : "org.deepin.dde.lightdm-deepin-greeter";
+    m_dconfig = DConfig::create(dconfigFile, dconfigFile, QString(), this);
     //华为机型,从override配置中获取是否加载插件
     if (m_dconfig) {
         bool showPlugin = m_dconfig->value("enableOneKeylogin", false).toBool();
@@ -64,7 +68,6 @@ LoginModule::LoginModule(QObject *parent)
         if (!showPlugin)
             return;
     }
-
 
     initConnect();
     startCallHuaweiFingerprint();

--- a/plugins/one-key-login/login_module.h
+++ b/plugins/one-key-login/login_module.h
@@ -27,7 +27,6 @@
 #include "login_module_interface.h"
 
 #include "dtkcore_global.h"
-#include "public_func.h"
 #include <DSpinner>
 
 DCORE_BEGIN_NAMESPACE


### PR DESCRIPTION
登录插件使用了登录器的头文件，不应如此。

Log: 修复一键登录插件崩溃的问题
Task: https://pms.uniontech.com/task-view-176757.html
Influence: 一键登录
Change-Id: I1b4694b99f4acbf57def03fe5df87da7cbeef792