### PR TITLE
fix: wayland环境登陆/锁屏崩溃

### DIFF
--- a/src/global_util/keyboardmonitor/keyboardmonitor.cpp
+++ b/src/global_util/keyboardmonitor/keyboardmonitor.cpp
@@ -30,18 +30,23 @@
 
 DGUI_USE_NAMESPACE
 
-KeyboardMonitor::KeyboardMonitor() : QThread()
+KeyboardMonitor::KeyboardMonitor()
+    : QThread()
+    , m_keyBoardPlatform(nullptr)
 {
     if (DGuiApplicationHelper::isXWindowPlatform()) {
-        keyBoardPlatform = new KeyboardPlantformX11();
+        m_keyBoardPlatform = new KeyboardPlantformX11();
     } else {
 #ifdef USE_DEEPIN_WAYLAND
-        keyBoardPlatform = new KeyboardPlantformWayland();
+        m_keyBoardPlatform = new KeyboardPlantformWayland();
 #endif
     }
-    connect(keyBoardPlatform, &KeyBoardPlatform::capslockStatusChanged, this, &KeyboardMonitor::capslockStatusChanged);
-    connect(keyBoardPlatform, &KeyBoardPlatform::numlockStatusChanged, this, &KeyboardMonitor::numlockStatusChanged);
-    connect(keyBoardPlatform, &KeyBoardPlatform::initialized, this, &KeyboardMonitor::initialized);
+
+    if (m_keyBoardPlatform) {
+        connect(m_keyBoardPlatform, &KeyBoardPlatform::capslockStatusChanged, this, &KeyboardMonitor::capslockStatusChanged);
+        connect(m_keyBoardPlatform, &KeyBoardPlatform::numlockStatusChanged, this, &KeyboardMonitor::numlockStatusChanged);
+        connect(m_keyBoardPlatform, &KeyBoardPlatform::initialized, this, &KeyboardMonitor::initialized);
+    }
 }
 
 KeyboardMonitor *KeyboardMonitor::instance()
@@ -57,20 +62,32 @@ KeyboardMonitor *KeyboardMonitor::instance()
 
 bool KeyboardMonitor::isCapslockOn()
 {
-    return keyBoardPlatform->isCapslockOn();
+    if (!m_keyBoardPlatform)
+        return false;
+
+    return m_keyBoardPlatform->isCapslockOn();
 }
 
 bool KeyboardMonitor::isNumlockOn()
 {
-    return keyBoardPlatform->isNumlockOn();
+    if (!m_keyBoardPlatform)
+        return false;
+
+    return m_keyBoardPlatform->isNumlockOn();
 }
 
 bool KeyboardMonitor::setNumlockStatus(const bool &on)
 {
-    return keyBoardPlatform->setNumlockStatus(on);
+    if (!m_keyBoardPlatform)
+        return false;
+
+    return m_keyBoardPlatform->setNumlockStatus(on);
 }
 
 void KeyboardMonitor::run()
 {
-    keyBoardPlatform->run();
+    if (!m_keyBoardPlatform)
+        return;
+
+    m_keyBoardPlatform->run();
 }

--- a/src/global_util/keyboardmonitor/keyboardmonitor.h
+++ b/src/global_util/keyboardmonitor/keyboardmonitor.h
@@ -54,7 +54,7 @@ protected:
 
 private:
     KeyboardMonitor();
-    KeyBoardPlatform* keyBoardPlatform = nullptr;
+    KeyBoardPlatform* m_keyBoardPlatform;
 };
 
 #endif // KEYBOARDMONITOR_H

--- a/tests/wayland_test.cc
+++ b/tests/wayland_test.cc
@@ -1,4 +1,4 @@
-#include <KF5/KWayland/KWayland/Client/ddeseat.h>
+#include <KF5/KWayland/Client/ddeseat.h>
 
 int main(int argc, char *argv[])
 {


### PR DESCRIPTION
1.头文件路径错误导致判断wayland环境出错.
2.在没有kwayland环境的时候调用使用了空指针.

Log: 修复wayland环境下登陆/锁屏崩溃
Task: https://pms.uniontech.com/task-view-176903.html
Influence: wayland环境登陆/锁屏
Change-Id: I47cc764e0c847cab2b0daab6461f16a2930298b2