### PR TITLE
fix: 修复判断条件错误访问无效对象造成崩溃问题

### DIFF
--- a/src/session-widgets/auth_custom.cpp
+++ b/src/session-widgets/auth_custom.cpp
@@ -103,7 +103,9 @@ void AuthCustom::setCallback()
     callback.app_data = this;
     callback.authCallbackFun = AuthCustom::authCallBack;
     callback.messageCallbackFunc = AuthCustom::messageCallback;
-    m_module->setCallback(&callback);
+    if (m_module) {
+        m_module->setCallback(&callback);
+    }
 }
 
 void AuthCustom::initUi()
@@ -276,7 +278,7 @@ bool AuthCustom::event(QEvent *e)
         emit notifyResizeEvent();
 
         if (e->type() == QEvent::Show) {
-            if (m_module->content()->parent() != this) {
+            if (m_module && m_module->content() && m_module->content()->parent() != this) {
                 m_mainLayout->addWidget(m_module->content());
                 setFocusProxy(m_module->content());
                 // 重新设置传给插件的appData


### PR DESCRIPTION
判断条件错误，导致访问了无效的对象而崩溃

Log: 修复设置仅单屏显示后，注销/重启系统显示黑屏和鼠标，需要拔掉HDMI线重启系统的问题
Bug: https://pms.uniontech.com/bug-view-150915.html
Influence: 设置仅单屏显示后正常注销或重启登录系统
Change-Id: I58ab57268d85b3a6ad646591fdff3accda95caf9