### PR TITLE
fix: 右键菜单弹出后可以使用快捷键

### DIFF
--- a/src/widgets/controlwidget.cpp
+++ b/src/widgets/controlwidget.cpp
@@ -46,6 +46,7 @@
 #include <QPainter>
 #include <QWheelEvent>
 #include <QMenu>
+#include <QWindow>
 
 #define BUTTON_ICON_SIZE QSize(26,26)
 #define BUTTON_SIZE QSize(52,52)
@@ -311,6 +312,14 @@ void ControlWidget::addModule(module::BaseModuleInterface *module)
         QAction *action = m_contextMenu->exec(QCursor::pos());
         if (action)
             trayModule->invokedMenuItem(action->data().toString(), true);
+
+        // 右键菜单隐藏后需要重新grab键盘，否则会导致快捷键重新生效
+        if (!m_model->isUseWayland()) {
+            QWindow *winHandle = topLevelWidget()->windowHandle();
+            if (!winHandle || !winHandle->setKeyboardGrabEnabled(true)) {
+                qWarning() << "Grab keyboard failed";
+            }
+        }
     });
 
     connect(button, &FlotingButton::requestShowTips, this, [ = ] {


### PR DESCRIPTION
修复方案：右键菜单隐藏的时候重新grab keyboard

Log: 修复右键菜单弹出后可以使用快捷键的问题
Task: https://pms.uniontech.com/task-view-172789.html
Influence: 登录弹出右键菜单后使用alt+tab快捷键
Change-Id: Ie8c00b2cfa99ce23eb1208ccd7ade797f82982b5
(cherry picked from commit 74c4ba962921b5cb15a12770e844b60db56bdcaf)
(cherry picked from commit d8ff9d8fcf84aa24542b64a2ae6f4779fc5f476c)