### PR TITLE
fix: 密码验证界面显示时根据锁定状态显示或隐藏重置密码按钮

### DIFF
--- a/src/session-widgets/auth_password.cpp
+++ b/src/session-widgets/auth_password.cpp
@@ -603,6 +603,24 @@ void AuthPassword::hideEvent(QHideEvent *event)
     AuthModule::hideEvent(event);
 }
 
+void AuthPassword::showEvent(QShowEvent *event)
+{
+    m_passwordHintBtn->setVisible(m_limitsInfo->numFailures > 0 && !m_passwordHint.isEmpty());
+    if (m_limitsInfo->locked) {
+        setAuthState(AS_Locked, "Locked");
+        if (QFile::exists(ResetPassword_Exe_Path) && m_currentUid <= 9999 && !IsCommunitySystem ) {
+            qDebug() << "begin reset passoword";
+            setResetPasswordMessageVisible(true);
+            updateResetPasswordUI();
+        }
+    } else {
+        setResetPasswordMessageVisible(false);
+        updateResetPasswordUI();
+    }
+
+    AuthModule::showEvent(event);
+}
+
 void AuthPassword::setAuthStatueVisible(bool visible)
 {
     m_showAuthState = visible;

--- a/src/session-widgets/auth_password.h
+++ b/src/session-widgets/auth_password.h
@@ -72,6 +72,7 @@ public slots:
 protected:
     bool eventFilter(QObject *watched, QEvent *event) override;
     void hideEvent(QHideEvent *event) override;
+    void showEvent(QShowEvent *event) override;
 
 private:
     void initUI();


### PR DESCRIPTION
用户密码已被锁定后启动锁屏界面，此时密码界面还没有显示，此时响应锁定信号时无法显示重置密码按钮。
因此在密码验证界面在显示时再次判断下密码是否锁定，密码被锁定就显示重置密码按钮

Log: 修复开启自动登录，锁屏界面，输错5次密码，关机后开机，进入桌面，执行快捷键锁屏，忘记密码框不显示问题
Bug: https://pms.uniontech.com/bug-view-153055.html
Influence: 显示重置密码按钮