### PR TITLE
fix: S3/S4之后一键开机进入系统，停留在了密码验证界面

### DIFF
--- a/src/session-widgets/sfa_widget.cpp
+++ b/src/session-widgets/sfa_widget.cpp
@@ -1075,8 +1075,11 @@ void SFAWidget::initAccount()
 
 void SFAWidget::onRequestChangeAuth(const int authType)
 {
-    qInfo() << Q_FUNC_INFO <<  authType;
-    if(!m_chooseAuthButtonBox->isEnabled() || m_currentAuthType != AT_Custom){
+    qInfo() << Q_FUNC_INFO << "authType" << authType << "m_chooseAuthButtonBox->isEnabled()" << m_chooseAuthButtonBox->isEnabled()
+               << "m_currentAuthType" << m_currentAuthType;
+
+    //当在S3/S4阶段时，会获取前一次认证的认证类型（不是AT_Custom），这时认证失败，也需要跳转到指纹认证
+    if(!m_chooseAuthButtonBox->isEnabled() || (m_currentAuthType != AT_Custom && m_model->appType() == AuthCommon::AppType::Login)) {
         return;
     }
 


### PR DESCRIPTION
S3/S4阶段一键开机进入系统失败，会判断上一次登录的类型，导致不能切换到指纹登录

Log: S3/S4之后一键开机进入系统，停留在了密码验证界面
Bug: https://pms.uniontech.com/bug-view-153817.html
Influence: 一键指纹登录插件系统，S3/S4阶段