### PR TITLE
feat: 1050update2-klv-默认显示缩放比由100%调整为150%

### DIFF
--- a/configs/org.deepin.dde.lightdm-deepin-greeter.json
+++ b/configs/org.deepin.dde.lightdm-deepin-greeter.json
@@ -61,6 +61,16 @@
             "description": "华为了电脑一键登录是否加载插件；false：不加载，true：加载。默认值为false；",
             "permissions": "readwrite",
             "visibility": "private"
+        },        
+	 "defaultScaleFactors":{
+            "value": 1,
+            "serial": 0,
+            "flags": ["global"],
+            "name": "DefaultScaleFactors",
+            "name[zh_CN]": "登录页面默认缩放",
+            "description": "配置greeter界面默认的缩放比例",
+            "permissions": "readwrite",
+            "visibility": "private"
         }
     }
 }


### PR DESCRIPTION
在wayland模式下配置greeter界面的默认缩放比例

Log: 1050update2-klv-默认显示缩放比由100%调整为150%
Task: https://pms.uniontech.com/task-view-156941.html
Influence: 登录界面缩放