### PR TITLE
fix: 锁屏第一次启动的时候没有验证框

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ build*/
 *.vscode
 tests/report/*
 .transifexrc
+.cache/


### PR DESCRIPTION
现象：锁屏第一次启动的时候，如果鼠标在副屏上，没有显示登陆框。
修改方案：跟产品确认登录框显示在鼠标所在的屏幕即可，不需要关注主屏是哪个；而且在wayland下是没有主屏这个概念的。

Log: 修复锁屏第一次启动的时候没有验证框的问题
Task: https://pms.uniontech.com/task-view-155755.html
Influence: 锁屏、登陆界面多屏的场景
Change-Id: I51b1776013b1412d7715f7637f0d393988d184dd