### PR TITLE
fix: 构建LockContent时根据条件确定是否设置为PasswordMode模式

### DIFF
--- a/src/session-widgets/lockcontent.cpp
+++ b/src/session-widgets/lockcontent.cpp
@@ -31,7 +31,10 @@ LockContent::LockContent(SessionBaseModel *const model, QWidget *parent)
     , m_userListWidget(nullptr)
     , m_localServer(new QLocalServer(this))
 {
-    m_model->setCurrentModeState(SessionBaseModel::ModeStatus::PasswordMode);
+    // 在已显示关机或用户列表界面时，再插入另外一个显示器，会新构建一个LockContent，此时会设置为PasswordMode造成界面状态异常
+    if (!m_model->visible()) {
+        m_model->setCurrentModeState(SessionBaseModel::ModeStatus::PasswordMode);
+    }
 
     initUI();
     initConnections();


### PR DESCRIPTION
插入新显示器时会新构建LockContent，同时设置为PasswordMode模式，若此时为关机模式或用户列表模式时，会造成显示状态和验证状态异常。

Log: 修复在关机界面时插入新显示器，界面无法输入密码和登录异常问题
Bug: https://pms.uniontech.com/bug-view-155051.html
Influence: 在关机界面插入显示器后正常解锁进入系统