### PR TITLE
fix: 修复锁屏下，在关机提示阻止页面按ESC键进入桌面的问题。

### DIFF
--- a/src/dde-lock/lockframe.cpp
+++ b/src/dde-lock/lockframe.cpp
@@ -311,7 +311,6 @@ void LockFrame::cancelShutdownInhibit(bool hideFrame)
     }
 
     if (hideFrame) {
-        m_model->setVisible(false);
         m_model->setCurrentModeState(SessionBaseModel::PasswordMode);
     }
 }


### PR DESCRIPTION
锁屏情况下，在阻止关机提示界面，按esc键后将锁屏关掉所导致问题，已修复。

Log: 修复锁屏下，在关机提示阻止页面按ESC键进入桌面的问题
Bug: https://pms.uniontech.com/bug-view-155137.html
Influence: 锁屏情况下阻止关机提示界面按esc后，锁屏是否显示及能否认证。