### PR TITLE
fix: 同步显示多屏的关机界面上当前选中的按钮

### DIFF
--- a/src/widgets/shutdownwidget.cpp
+++ b/src/widgets/shutdownwidget.cpp
@@ -421,7 +421,15 @@ void ShutdownWidget::onStatusChanged(SessionBaseModel::ModeStatus status)
         roundItemButton = m_requireShutdownButton;
     }
 
-    int index = m_btnList.indexOf(roundItemButton);
+    // 同步显示另一个显示器关机界面上当前选中的按钮，若还未同步则显示关机或锁屏默认按钮
+    if (m_index >= 0 && m_index < m_btnList.size()) {
+        RoundItemButton * tmpBtn = m_btnList.at(m_index);
+        if (tmpBtn && tmpBtn->isVisible()) {
+            roundItemButton = tmpBtn;
+        }
+    }
+
+    int index =  m_btnList.indexOf(roundItemButton);
     roundItemButton->updateState(RoundItemButton::Checked);
     m_frameDataBind->updateValue("ShutdownWidget", index);
 
@@ -546,12 +554,15 @@ bool ShutdownWidget::event(QEvent *e)
     }
 
     if (e->type() == QEvent::FocusIn) {
-        if (m_index < 0) {
+        if (m_index < 0 || m_index >= m_btnList.size()) {
             m_index = 0;
         }
         m_frameDataBind->updateValue("ShutdownWidget", m_index);
         m_btnList.at(m_index)->updateState(RoundItemButton::Checked);
     } else if (e->type() == QEvent::FocusOut) {
+        if (m_index < 0 || m_index >= m_btnList.size()) {
+            m_index = 0;
+        }
         m_btnList.at(m_index)->updateState(RoundItemButton::Normal);
     }
 
@@ -562,6 +573,12 @@ void ShutdownWidget::showEvent(QShowEvent *event)
 {
     setFocus();
     QFrame::showEvent(event);
+}
+
+void ShutdownWidget::hideEvent(QHideEvent *event)
+{
+    m_index = -1;
+    QFrame::hideEvent(event);
 }
 
 void ShutdownWidget::updateLocale(std::shared_ptr<User> user)

--- a/src/widgets/shutdownwidget.h
+++ b/src/widgets/shutdownwidget.h
@@ -69,6 +69,7 @@ protected:
     void keyPressEvent(QKeyEvent *event) Q_DECL_OVERRIDE;
     bool event(QEvent *e) Q_DECL_OVERRIDE;
     void showEvent(QShowEvent *event) Q_DECL_OVERRIDE;
+    void hideEvent(QHideEvent *event) Q_DECL_OVERRIDE;
 
 private:
     void initUI();


### PR DESCRIPTION
同步显示多屏的关机界面上当前选中的按钮

Log: 修复打开电源管理界面，选中休眠，将鼠标移动到外显上，休眠变成了锁定的问题
Bug: https://pms.uniontech.com/bug-view-155039.html
Influence: 切换不同显示器后关机界面选中相同的按钮