### PR TITLE
fix: 修复触发lockService.Visible信号参数值不对问题

### DIFF
--- a/src/app/dde-lock.cpp
+++ b/src/app/dde-lock.cpp
@@ -177,7 +177,7 @@ int main(int argc, char *argv[])
         }
 
         lockFrame->setVisible(model->visible());
-        emit lockService.Visible(true);
+        emit lockService.Visible(model->visible());
         return lockFrame;
     };
 


### PR DESCRIPTION
在插入新的显示器时会构建一个对应的LockFrame界面，同时触发lockService.Visible信号， 但是触发信号的参数值不对。

Log: 修复机器接入外显扩展模式正在播放的视频停止播放的问题
Bug: https://pms.uniontech.com/bug-view-150245.html
Influence: 插入显示器时播放器继续正常播放