### PR TITLE
fix: 切换用户登陆界面崩溃

### DIFF
--- a/src/global_util/modules_loader.cpp
+++ b/src/global_util/modules_loader.cpp
@@ -149,5 +149,13 @@ void ModulesLoader::findModule(const QString &path)
     }
 }
 
+void ModulesLoader::removeModule(const QString &moduleKey)
+{
+    if (!m_modules.contains(moduleKey))
+        return;
+
+    m_modules.remove(moduleKey);
+}
+
 } // namespace module
 } // namespace dss

--- a/src/global_util/modules_loader.h
+++ b/src/global_util/modules_loader.h
@@ -39,6 +39,7 @@ public:
     inline QHash<QString, QSharedPointer<BaseModuleInterface>> moduleList() { return m_modules; }
     BaseModuleInterface *findModuleByName(const QString &name) const;
     QHash<QString, BaseModuleInterface *> findModulesByType(const int type) const;
+    void removeModule(const QString &moduleKey);
 
 signals:
     void moduleFound(BaseModuleInterface *);

--- a/src/session-widgets/auth_custom.cpp
+++ b/src/session-widgets/auth_custom.cpp
@@ -56,12 +56,11 @@ AuthCustom::~AuthCustom()
         m_module->content()->setParent(nullptr);
     }
 
+    // FIXME 这种处理方式不通用，应该由插件请求登陆器把自己卸载掉
     AuthCustomObjs.removeAll(this);
-
     if (AuthCustomObjs.isEmpty()) {
         if (m_module) {
-            delete m_module;
-            m_module = nullptr;
+            ModulesLoader::instance().removeModule(m_module->key());
         }
     }
 }


### PR DESCRIPTION
销毁对象的时候没有从loader中移除插件对象

Log: 修复切换用户登陆界面崩溃的问题
Bug: https://pms.uniontech.com/bug-view-155355.html
Influence: 切换用户
Change-Id: I860ae61f08cf192d9e58284db0031a2082a39ea9