### PR TITLE
fix: 待机刚唤醒一段时间内不响应电源按键事件

### DIFF
--- a/src/dde-lock/lockframe.cpp
+++ b/src/dde-lock/lockframe.cpp
@@ -232,8 +232,11 @@ bool LockFrame::handlePoweroffKey()
     qDebug() << "battery is: " << isBattery << "," << action;
     // 需要特殊处理：关机(0)和无任何操作(4)
     if (action == 0) {
-        //锁屏时或显示关机界面时，需要确认是否关机
-        emit m_model->onRequirePowerAction(SessionBaseModel::PowerAction::RequireShutdown, false);
+        // 待机刚唤醒一段时间内不响应电源按键事件
+        if (m_enablePowerOffKey) {
+            //锁屏时或显示关机界面时，需要确认是否关机
+            emit m_model->onRequirePowerAction(SessionBaseModel::PowerAction::RequireShutdown, false);
+        }
         return true;
     } else if (action == 4) {
         // 先检查当前是否允许响应电源按键


### PR DESCRIPTION
待机刚唤醒一段时间内不响应电源按键事件

Log: 修复设置按电源按钮为“关机”，待机按电源按钮唤醒后出现注销的问题
Bug: https://pms.uniontech.com/bug-view-151771.html
Influence: 待机后使用电源按键正常唤醒