### PR TITLE
fix: 锁屏或登录界面重置密码消息异常显示

### DIFF
--- a/src/session-widgets/auth_module.h
+++ b/src/session-widgets/auth_module.h
@@ -41,6 +41,7 @@
 #define AUTH_LOCK QStringLiteral(":/misc/images/unlock/unlock_1.svg")
 #define UnionID_Auth QStringLiteral(":/misc/images/auth/UnionID.svg")
 #define ResetPassword_Exe_Path QStringLiteral("/usr/lib/dde-control-center/reset-password-dialog")
+#define DEEPIN_DEEPINID_DAEMON_PATH QStringLiteral("/usr/lib/deepin-deepinid-daemon/deepin-deepinid-daemon")
 
 DWIDGET_USE_NAMESPACE
 using namespace DDESESSIONCC;

--- a/src/session-widgets/auth_password.cpp
+++ b/src/session-widgets/auth_password.cpp
@@ -301,7 +301,7 @@ void AuthPassword::setLimitsInfo(const LimitsInfo &info)
     m_passwordHintBtn->setVisible(info.numFailures > 0 && !m_passwordHint.isEmpty());
     if (m_limitsInfo->locked) {
         setAuthState(AS_Locked, "Locked");
-        if (this->isVisible() && QFile::exists(ResetPassword_Exe_Path) && m_currentUid <= 9999 && !IsCommunitySystem ) {
+        if (this->isVisible() && isShowResetPasswordMessage()) {
             qDebug() << "begin reset passoword";
             setResetPasswordMessageVisible(true);
             updateResetPasswordUI();
@@ -581,6 +581,11 @@ void AuthPassword::updateResetPasswordUI()
     }
 }
 
+bool AuthPassword::isShowResetPasswordMessage()
+{
+    return QFile::exists(DEEPIN_DEEPINID_DAEMON_PATH) && QFile::exists(ResetPassword_Exe_Path) && m_currentUid <= 9999 && !IsCommunitySystem;
+}
+
 bool AuthPassword::eventFilter(QObject *watched, QEvent *event)
 {
     if (qobject_cast<DLineEditEx *>(watched) == m_lineEdit && event->type() == QEvent::KeyPress) {
@@ -608,7 +613,7 @@ void AuthPassword::showEvent(QShowEvent *event)
     m_passwordHintBtn->setVisible(m_limitsInfo->numFailures > 0 && !m_passwordHint.isEmpty());
     if (m_limitsInfo->locked) {
         setAuthState(AS_Locked, "Locked");
-        if (QFile::exists(ResetPassword_Exe_Path) && m_currentUid <= 9999 && !IsCommunitySystem ) {
+        if (isShowResetPasswordMessage()) {
             qDebug() << "begin reset passoword";
             setResetPasswordMessageVisible(true);
             updateResetPasswordUI();

--- a/src/session-widgets/auth_password.h
+++ b/src/session-widgets/auth_password.h
@@ -58,6 +58,7 @@ public:
     void closeResetPasswordMessage();
     void setAuthStatueVisible(bool visible);
 
+    bool isShowResetPasswordMessage();
 signals:
     void focusChanged(const bool);
     void lineEditTextChanged(const QString &); // 数据同步

--- a/src/session-widgets/auth_single.cpp
+++ b/src/session-widgets/auth_single.cpp
@@ -273,8 +273,9 @@ void AuthSingle::setLimitsInfo(const LimitsInfo &info)
     AuthModule::setLimitsInfo(info);
     setPasswordHintBtnVisible(info.numFailures > 0 && !m_passwordHint.isEmpty());
     if (m_limitsInfo->locked) {
-        if (lockStateChanged && this->isVisible() && QFile::exists(ResetPassword_Exe_Path) &&
-            m_currentUid <= 9999 && !IsCommunitySystem ) {
+        bool isShow = lockStateChanged && this->isVisible() && QFile::exists(DEEPIN_DEEPINID_DAEMON_PATH) &&
+                QFile::exists(ResetPassword_Exe_Path) && m_currentUid <= 9999 && !IsCommunitySystem;
+        if (isShow) {
             qDebug() << "begin reset passoword";
             setResetPasswordMessageVisible(true);
             updateResetPasswordUI();


### PR DESCRIPTION
当没有同步模块的文件（deepin-deepinid-daemon）时，说明不支持通过UOS
ID的方式去重置密码
此时不应该显示重置密码的消息按钮

Log: 解决锁屏或登录界面重置密码消息异常显示的问题
Bug: https://pms.uniontech.com/bug-view-154695.html
Influence: 锁屏/登录界面重置密码功能
Change-Id: I94d30768756a3c94472d5a2d87ac13c347700bcc