### PR TITLE
fix: 待机刚唤醒一段时间内不响应电源按键事件

### DIFF
--- a/src/dde-lock/lockframe.cpp
+++ b/src/dde-lock/lockframe.cpp
@@ -232,8 +232,11 @@ bool LockFrame::handlePoweroffKey()
     qDebug() << "battery is: " << isBattery << "," << action;
     // 需要特殊处理：关机(0)和无任何操作(4)
     if (action == 0) {
-        //锁屏时或显示关机界面时，需要确认是否关机
-        emit m_model->onRequirePowerAction(SessionBaseModel::PowerAction::RequireShutdown, false);
+        // 待机刚唤醒一段时间内不响应电源按键事件
+        if (m_enablePowerOffKey) {
+            //锁屏时或显示关机界面时，需要确认是否关机
+            emit m_model->onRequirePowerAction(SessionBaseModel::PowerAction::RequireShutdown, false);
+        }
         return true;
     } else if (action == 4) {
         // 先检查当前是否允许响应电源按键

--- a/src/dde-lock/lockworker.cpp
+++ b/src/dde-lock/lockworker.cpp
@@ -369,6 +369,8 @@ void LockWorker::doPowerAction(const SessionBaseModel::PowerAction action)
             delayTime = 500;
         }
         QTimer::singleShot(delayTime, this, [=] {
+            // 待机休眠前设置Locked为true,避免刚唤醒时locked状态不对
+            setLocked(true);
             m_sessionManagerInter->RequestSuspend();
         });
     }
@@ -386,6 +388,8 @@ void LockWorker::doPowerAction(const SessionBaseModel::PowerAction action)
             delayTime = 500;
         }
         QTimer::singleShot(delayTime, this, [=] {
+            // 待机休眠前设置Locked为true,避免刚唤醒时locked状态不对
+            setLocked(true);
             m_sessionManagerInter->RequestHibernate();
         });
     }
@@ -695,13 +699,6 @@ void LockWorker::onUnlockFinished(bool unlocked)
     //To Do: 最好的方案是修改同步后端认证信息的代码设计
     if (m_model->currentModeState() == SessionBaseModel::ModeStatus::UserMode)
         m_model->setCurrentModeState(SessionBaseModel::ModeStatus::PasswordMode);
-
-    //    if (!unlocked && m_authFramework->GetAuthType() == AuthFlag::Password) {
-    //        qWarning() << "Authorization password failed!";
-    //        emit m_model->authFailedTipsMessage(tr("Wrong Password"));
-    //        return;
-    //    }
-
     switch (m_model->powerAction()) {
     case SessionBaseModel::PowerAction::RequireRestart:
         if (unlocked) {


### PR DESCRIPTION
1 待机休眠时设置Locked状态为true,避免刚唤醒时locked状态不对，后端需要判断此状态确定是否响应电源按键事件；
2 锁屏界面在待机刚唤醒的一段时间内不响应电源按键事件

Log: 修复设置按电源按钮为“关机”，待机按电源按钮唤醒后出现注销的问题
Bug: https://pms.uniontech.com/bug-view-151771.html
Influence: 待机后使用电源按键正常唤醒