### PR TITLE
fix: 修复登录界面切换账户不清除密码框的问题。

### DIFF
--- a/src/session-widgets/auth_widget.cpp
+++ b/src/session-widgets/auth_widget.cpp
@@ -199,6 +199,11 @@ void AuthWidget::setUser(std::shared_ptr<User> user)
     if (m_passwordAuth) {
         m_passwordAuth->setCurrentUid(user->uid());
     }
+
+    // A账户为无密码登录，B账户有密码；在登录界面的时候，B账户输入密码不登录，切换到A，再切换到B，发现B的密码输入框还有密码。
+    if (m_passwordAuth) {
+        m_passwordAuth->reset();
+    }
 }
 
 /**


### PR DESCRIPTION
登录界面切换用户，遇到无密码登录和无登录用户切换时，未清除旧密码框输入导致的问题。

Log: 修复登录界面切换账户不清除密码框的问题。
Bug: https://pms.uniontech.com/bug-view-155353.html
Influence: 登录界面切换用户，密码输入框有无旧输入。