### PR TITLE
fix: 修复锁屏界面取消关机重启注销操作后是进入桌面还是锁屏的问题。

### DIFF
--- a/src/dde-lock/lockframe.cpp
+++ b/src/dde-lock/lockframe.cpp
@@ -313,7 +313,13 @@ void LockFrame::cancelShutdownInhibit(bool hideFrame)
         setContentVisible(true);
     }
 
-    if (hideFrame) {
+    if (old_visible && hideFrame) {
+        // 从lock点的power btn，不能隐藏锁屏而进入桌面
+        if (!m_model->isPressedPowerBtnFromLock()) {
+            m_model->setVisible(false);
+        }
+
+        m_model->resetPowerBtnPressedFromLock();
         m_model->setCurrentModeState(SessionBaseModel::PasswordMode);
     }
 }

--- a/src/session-widgets/lockcontent.cpp
+++ b/src/session-widgets/lockcontent.cpp
@@ -104,6 +104,9 @@ void LockContent::initConnections()
         emit requestEndAuthentication(m_model->currentUser()->name(), AT_All);
     });
     connect(m_controlWidget, &ControlWidget::requestShutdown, this, [ = ] {
+        if (m_model->appType() == AuthCommon::Lock)
+            m_model->powerBtnPressedFromLock();
+
         m_model->setCurrentModeState(SessionBaseModel::ModeStatus::PowerMode);
     });
     connect(m_controlWidget, &ControlWidget::requestSwitchVirtualKB, this, &LockContent::toggleVirtualKB);
@@ -375,6 +378,11 @@ void LockContent::mouseReleaseEvent(QMouseEvent *event)
         emit requestSwitchToUser(m_model->currentUser());
     }
 
+    if (m_model->currentModeState() == SessionBaseModel::ShutDownMode
+        || m_model->currentModeState() == SessionBaseModel::PowerMode) {
+        m_model->resetPowerBtnPressedFromLock();
+    }
+
     m_model->setCurrentModeState(SessionBaseModel::ModeStatus::PasswordMode);
 
     SessionBaseWindow::mouseReleaseEvent(event);
@@ -627,6 +635,11 @@ void LockContent::keyPressEvent(QKeyEvent *event)
         }
         break;
     case Qt::Key_Escape:
+        if (m_model->currentModeState() == SessionBaseModel::ShutDownMode
+            || m_model->currentModeState() == SessionBaseModel::PowerMode) {
+            m_model->resetPowerBtnPressedFromLock();
+        }
+
         if (m_model->currentModeState() == SessionBaseModel::ModeStatus::ConfirmPasswordMode) {
             m_model->setAbortConfirm(false);
             m_model->setPowerAction(SessionBaseModel::PowerAction::None);

--- a/src/session-widgets/sessionbasemodel.cpp
+++ b/src/session-widgets/sessionbasemodel.cpp
@@ -25,6 +25,7 @@ SessionBaseModel::SessionBaseModel(QObject *parent)
     , m_allowShowCustomUser(false)
     , m_SEOpen(false)
     , m_isUseWayland(QGuiApplication::platformName().startsWith("wayland", Qt::CaseInsensitive))
+    , m_pressedPowerBtnFromLock(false)
     , m_appType(AuthCommon::None)
     , m_currentUser(nullptr)
     , m_lastLogoutUser(nullptr)
@@ -234,6 +235,16 @@ void SessionBaseModel::setAllowShowCustomUser(const bool allowShowCustomUser)
         return;
 
     m_allowShowCustomUser = allowShowCustomUser;
+}
+
+void SessionBaseModel::powerBtnPressedFromLock()
+{
+    m_pressedPowerBtnFromLock = true;
+}
+
+void SessionBaseModel::resetPowerBtnPressedFromLock()
+{
+    m_pressedPowerBtnFromLock = false;
 }
 
 /**

--- a/src/session-widgets/sessionbasemodel.h
+++ b/src/session-widgets/sessionbasemodel.h
@@ -129,6 +129,10 @@ public:
     inline bool allowShowCustomUser() const { return m_allowShowCustomUser; }
     void setAllowShowCustomUser(const bool allowShowCustomUser);
 
+    inline bool isPressedPowerBtnFromLock() const { return m_pressedPowerBtnFromLock; }
+    void powerBtnPressedFromLock();
+    void resetPowerBtnPressedFromLock();
+
     inline const QList<std::shared_ptr<User>> getUserList() const { return m_users->values(); }
 
     inline const AuthProperty &getAuthProperty() const { return m_authProperty; }
@@ -220,6 +224,7 @@ private:
     bool m_allowShowCustomUser;
     bool m_SEOpen; // 保存等保开启、关闭的状态
     bool m_isUseWayland;
+    bool m_pressedPowerBtnFromLock; // 从lock界面点的power按键
     int m_userListSize = 0;
     AppType m_appType;
     QList<std::shared_ptr<User>> m_userList;

--- a/src/widgets/warningcontent.cpp
+++ b/src/widgets/warningcontent.cpp
@@ -150,6 +150,7 @@ void WarningContent::doAccecpShutdownInhibit()
 
     m_model->setIsCheckedInhibit(true);
     m_model->setPowerAction(m_powerAction);
+    m_model->resetPowerBtnPressedFromLock();
     if (m_model->currentModeState() != SessionBaseModel::ModeStatus::ShutDownMode)
         emit m_model->cancelShutdownInhibit(false);
 }


### PR DESCRIPTION
锁屏界面上操作电源btn，触发取消关机重启注销操作后，应该回到锁屏界面；任务上电源按钮右键操作触发的关机页面做上述操作后，应该回到桌面。修复方案为标记锁屏界面电源btn触发的情况，取消上述操作后回到锁屏，任务栏上操作最终回到桌面。

Log: 修复锁屏界面取消关机重启注销操作后是进入桌面还是锁屏的问题。
Bug: https://pms.uniontech.com/bug-view-151421.html
Bug: https://pms.uniontech.com/bug-view-155809.html
Influence: 锁屏上电源按钮、任务栏电源按钮、物理电源按钮触发关机重启注销页面后，取消操作（ESC/点击空白处）后显示情况，以及能否认证。