### PR TITLE
fix: 处理多账户设置不同显示模式，切换账户锁屏崩溃

### DIFF
--- a/src/widgets/fullscreenbackground.cpp
+++ b/src/widgets/fullscreenbackground.cpp
@@ -395,10 +395,10 @@ void FullscreenBackground::updateScreen(QPointer<QScreen> screen)
         disconnect(m_screen, &QScreen::geometryChanged, this, &FullscreenBackground::updateGeometry);
 
     if (!screen.isNull()) {
-        connect(screen, &QScreen::geometryChanged, [=](){
+        connect(screen, &QScreen::geometryChanged, this, [=](){
             qInfo() << "screen geometry changed:" << screen << " lockframe:" << this;
-        });
-        connect(screen, &QScreen::geometryChanged, this, &FullscreenBackground::updateGeometry);
+        }, Qt::ConnectionType::QueuedConnection);
+        connect(screen, &QScreen::geometryChanged, this, &FullscreenBackground::updateGeometry, Qt::ConnectionType::QueuedConnection);
     }
 
     m_screen = screen;


### PR DESCRIPTION
处理多账户设置不同显示模式，切换账户锁屏崩溃

Log: 处理多账户设置不同显示模式，切换账户锁屏崩溃
Influence: 多账户多屏模式切换
Bug: https://pms.uniontech.com/bug-view-156083.html
Change-Id: Ie614095e8ae3791780d0e2f73da32b7565a40c37