### PR TITLE
fix: 修复关机页面拔掉显示器后按钮丢失默认选中状态的问题。

### DIFF
--- a/src/widgets/shutdownwidget.cpp
+++ b/src/widgets/shutdownwidget.cpp
@@ -539,10 +539,16 @@ bool ShutdownWidget::event(QEvent *e)
         m_frameDataBind->updateValue("ShutdownWidget", m_index);
         m_btnList.at(m_index)->updateState(RoundItemButton::Checked);
     } else if (e->type() == QEvent::FocusOut) {
-        if (m_index < 0 || m_index >= m_btnList.size()) {
-            m_index = 0;
+        if (m_model->currentModeState() == SessionBaseModel::ModeStatus::ShutDownMode) {
+            // 丢失焦点后，获取焦点。双屏拔掉一个显示器会导致焦点丢失
+            if (this->isVisible())
+                this->activateWindow();
+        } else {
+            if (m_index < 0 || m_index >= m_btnList.size()) {
+                m_index = 0;
+            }
+            m_btnList.at(m_index)->updateState(RoundItemButton::Normal);
         }
-        m_btnList.at(m_index)->updateState(RoundItemButton::Normal);
     }
 
     return QFrame::event(e);


### PR DESCRIPTION
双屏显示，拔掉主屏幕的显示器后，会导致副屏上的shutdownwidget页面丢失焦点，从而将按钮默认选中状态置为normal导致的问题。已修复为shutdownMode的时候丢失焦点后，将页面activeWindow。

Log: 修复关机页面拔掉显示器后按钮丢失默认选中状态的问题。
Bug: https://pms.uniontech.com/bug-view-156061.html
Influence: 锁屏上点电源按钮->虚拟键盘，查看关机按钮选中状态是否是无；