### PR TITLE
fix:  全屏背景出来后，需要触发一次更新才能保证没显示透明状态

### DIFF
--- a/src/app/dde-lock.cpp
+++ b/src/app/dde-lock.cpp
@@ -137,7 +137,10 @@ int main(int argc, char *argv[])
         lockFrame->setScreen(screen, count <= 0);
         property_group->addObject(lockFrame);
         QObject::connect(lockFrame, &LockFrame::requestSwitchToUser, worker, &LockWorker::switchToUser);
-        QObject::connect(model, &SessionBaseModel::visibleChanged, lockFrame, &LockFrame::setVisible);
+        QTimer::singleShot(300, [=]() {
+            qInfo() << "lockFrame setVisible true, update.";
+            lockFrame->update();
+        });
         QObject::connect(model, &SessionBaseModel::visibleChanged, lockFrame,[&](bool visible) {
             emit lockService.Visible(visible);
         });


### PR DESCRIPTION
窗管问题
出现该Bug情况的时候，需要再刷新一次页面才能恢复正常，也可以通过下面命令恢复：
qdbus org.kde.KWin /Effects loadEffect 'com.deepin.blur'

Log: 规避窗管问题
Influence: 点击桌面后快捷键切出shutdown页面
Bug: https://pms.uniontech.com/bug-view-155815.html
Change-Id: Iaa9635184eac73eb26edcd8cf32674555dcf9d1a