### PR TITLE
fix: 人脸验证成功后直接进入桌面

### DIFF
--- a/interface/login_module_interface.h
+++ b/interface/login_module_interface.h
@@ -67,6 +67,27 @@ enum AuthType {
 };
 
 /**
+ * @brief The AuthStatus enum
+ * 认证状态
+ */
+enum AuthState {
+    AS_None = -1,   // none
+    AS_Success,     // 成功，此次认证的最终结果
+    AS_Failure,     // 失败，此次认证的最终结果
+    AS_Cancel,      // 取消，当认证没有给出最终结果时，调用 End 会出发 Cancel 信号
+    AS_Timeout,     // 超时
+    AS_Error,       // 错误
+    AS_Verify,      // 验证中
+    AS_Exception,   // 设备异常，当前认证会被 End
+    AS_Prompt,      // 设备提示
+    AS_Started,     // 认证已启动，调用 Start 之后，每种成功开启都会发送此信号
+    AS_Ended,       // 认证已结束，调用 End 之后，每种成功关闭的都会发送此信号，当某种认证类型被锁定时，也会触发此信号
+    AS_Locked,      // 认证已锁定，当认证类型锁定时，触发此信号。该信号不会给出锁定等待时间信息
+    AS_Recover,     // 设备恢复，需要调用 Start 重新开启认证，对应 AS_Exception
+    AS_Unlocked     // 认证解锁，对应 AS_Locked
+};
+
+/**
  * @brief 验证回调函数
  * @param const AuthCallbackData * 需要传回的验证数据
  * @param void * 登录器回传指针

--- a/plugins/examples/login-plugins/login-complex/login_module.cpp
+++ b/plugins/examples/login-plugins/login-complex/login_module.cpp
@@ -140,6 +140,13 @@ std::string LoginModule::onMessage(const std::string &message)
         retDataObj["ShowLockButton"] = false;
         retDataObj["DefaultAuthLevel"] = DefaultAuthLevel::Default;
         retObj["Data"] = retDataObj;
+    } else if (cmdType == "AuthState") {
+        int authType = data.value("AuthType").toInt();
+        int authState = data.value("AuthState").toInt();
+        // 所有类型验证成功，重置插件状态
+        if (authType == AuthType::AT_All && authState == AuthState::AS_Success) {
+            init();
+        }
     }
 
     QJsonDocument doc;

--- a/src/session-widgets/auth_custom.cpp
+++ b/src/session-widgets/auth_custom.cpp
@@ -110,8 +110,6 @@ void AuthCustom::reset()
 {
     qInfo() << Q_FUNC_INFO << "Reset custom auth";
     m_currentAuthData = AuthCallbackData();
-    if (m_module)
-        m_module->init();
 }
 
 
@@ -331,4 +329,16 @@ void AuthCustom::lightdmAuthStarted()
     message["AuthObjectType"] = AuthObjectType::LightDM;
     std::string result = m_module->onMessage(toJson(message).toStdString());
     qInfo() << "Plugin result: " << QString::fromStdString(result);
+}
+
+void AuthCustom::notifyAuthState(AuthCommon::AuthType authType, AuthCommon::AuthState state)
+{
+    if (!m_module)
+        return;
+
+    QJsonObject message;
+    message["CmdType"] = "AuthState";
+    message["AuthType"] = authType;
+    message["AuthState"] = state;
+    m_module->onMessage(toJson(message).toStdString());
 }

--- a/src/session-widgets/auth_custom.h
+++ b/src/session-widgets/auth_custom.h
@@ -6,6 +6,7 @@
 #define AUTHCUTOM_H
 
 #include "auth_module.h"
+#include "authcommon.h"
 #include "login_module_interface.h"
 
 #include <QVBoxLayout>
@@ -44,9 +45,10 @@ public:
     inline AuthCommon::AuthType authType() const { return m_authType; }
     void sendAuthToken();
     void lightdmAuthStarted();
+    void notifyAuthState(AuthCommon::AuthType authType, AuthCommon::AuthState state);
 
 protected:
-    bool event(QEvent *e);
+    bool event(QEvent *e) override;
 
 private:
     void setCallback();

--- a/src/session-widgets/sfa_widget.cpp
+++ b/src/session-widgets/sfa_widget.cpp
@@ -11,6 +11,7 @@
 #include "auth_password.h"
 #include "auth_single.h"
 #include "auth_ukey.h"
+#include "authcommon.h"
 #include "dlineeditex.h"
 #include "framedatabind.h"
 #include "keyboardmonitor.h"
@@ -363,6 +364,11 @@ void SFAWidget::setAuthState(const int type, const int state, const QString &mes
         break;
     default:
         break;
+    }
+
+    // 同步验证状态给插件
+    if (m_customAuth) {
+        m_customAuth->notifyAuthState(static_cast<AuthCommon::AuthType>(type) , static_cast<AuthCommon::AuthState>(state));
     }
 }
 


### PR DESCRIPTION
原因：人脸认证成功后调用了reset函数，导致插件发起了一次验证，获取到成功的结果，从而进入了桌面
解决方案：同步认证结果给插件，由插件自己决定是否要重置界面或者其他信息，登陆器不做处理。

Log: 人脸验证成功后直接进入桌面
Bug: https://pms.uniontech.com/bug-view-156113.html
Influence: 华为设备人脸验证
Change-Id: Iaaa5d494c432b8617de638a795642d9a72ec6793