### PR TITLE
fix: 用户锁定状态下重启系统，登录框无法加载成功

### DIFF
--- a/plugins/one-key-login/login_module.cpp
+++ b/plugins/one-key-login/login_module.cpp
@@ -37,6 +37,7 @@ LoginModule::LoginModule(QObject *parent)
     , m_acceptSleepSignal(false)
     , m_authStatus(AuthStatus::None)
     , m_needSendAuthType(false)
+    , m_isLocked(false)
 {
     setObjectName(QStringLiteral("LoginModule"));
 
@@ -252,6 +253,10 @@ std::string LoginModule::onMessage(const std::string &message)
                 sendAuthTypeToSession(AuthType::AT_Fingerprint);
             }
         }
+    } else if (cmdType == "LimitsInfoIsLocked") {
+        qDebug() << Q_FUNC_INFO << "LimitsInfoIsLocked" << data.value("IsPwdLocked").toBool();
+        m_isLocked = data.value("IsPwdLocked").toBool();
+
     }
 
     QJsonDocument doc;
@@ -335,7 +340,7 @@ void LoginModule::sendAuthTypeToSession(AuthType type)
         return;
     }
     // 这里主要为了防止 在发送切换信号的时候,lightdm还为开启认证，导致切换类型失败
-    if (m_authStatus == AuthStatus::None && type != AuthType::AT_Custom && m_appType != AppType::Lock) {
+    if (m_authStatus == AuthStatus::None && !m_isLocked && type != AuthType::AT_Custom && m_appType != AppType::Lock) {
         m_needSendAuthType = true;
         return;
     }

--- a/plugins/one-key-login/login_module.h
+++ b/plugins/one-key-login/login_module.h
@@ -77,6 +77,7 @@ private:
     AuthCallbackData m_lastAuthResult;
     AuthStatus m_authStatus;
     bool m_needSendAuthType;
+    bool m_isLocked;
 };
 
 } // namespace module

--- a/src/session-widgets/auth_custom.cpp
+++ b/src/session-widgets/auth_custom.cpp
@@ -328,7 +328,25 @@ void AuthCustom::lightdmAuthStarted()
 
     QJsonObject message;
     message["CmdType"] = "StartAuth";
-    message["AuthObjectType"] = AuthObjectType::LightDM;
+    QJsonObject retDataObj;
+    retDataObj["AuthObjectType"] = AuthObjectType::LightDM;
+    message["Data"] = retDataObj;
+    std::string result = m_module->onMessage(toJson(message).toStdString());
+    qInfo() << "Plugin result: " << QString::fromStdString(result);
+}
+
+void AuthCustom::setIsPwdLocked(const bool isPwdLocked)
+{
+    qDebug() << Q_FUNC_INFO << isPwdLocked;
+    //把输密码错误五次后，是否锁定的信息传给插件
+    if (!m_module)
+        return;
+
+    QJsonObject message;
+    message["CmdType"] = "LimitsInfoIsLocked";
+    QJsonObject retDataObj;
+    retDataObj["IsPwdLocked"] = isPwdLocked;
+    message["Data"] = retDataObj;
     std::string result = m_module->onMessage(toJson(message).toStdString());
     qInfo() << "Plugin result: " << QString::fromStdString(result);
 }

--- a/src/session-widgets/auth_custom.h
+++ b/src/session-widgets/auth_custom.h
@@ -45,6 +45,8 @@ public:
     void sendAuthToken();
     void lightdmAuthStarted();
 
+    void setIsPwdLocked(const bool isPwdLocked);
+
 protected:
     bool event(QEvent *e);
 

--- a/src/session-widgets/auth_widget.cpp
+++ b/src/session-widgets/auth_widget.cpp
@@ -10,6 +10,7 @@
 #include "auth_password.h"
 #include "auth_single.h"
 #include "auth_ukey.h"
+#include "auth_custom.h"
 #include "dlineeditex.h"
 #include "framedatabind.h"
 #include "keyboardmonitor.h"
@@ -231,6 +232,8 @@ void AuthWidget::setLimitsInfo(const QMap<int, User::LimitsInfo> *limitsInfo)
     User::LimitsInfo limitsInfoTmpU;
     LimitsInfo limitsInfoTmp;
 
+    bool isPwdLocked = false;
+
     QMap<int, User::LimitsInfo>::const_iterator i = limitsInfo->constBegin();
     while (i != limitsInfo->end()) {
         limitsInfoTmpU = i.value();
@@ -246,6 +249,7 @@ void AuthWidget::setLimitsInfo(const QMap<int, User::LimitsInfo> *limitsInfo)
             }
             break;
         case AT_Password:
+            isPwdLocked = limitsInfoTmp.locked;
             if (m_passwordAuth) {
                 m_passwordAuth->setLimitsInfo(limitsInfoTmp);
             }
@@ -278,6 +282,10 @@ void AuthWidget::setLimitsInfo(const QMap<int, User::LimitsInfo> *limitsInfo)
             break;
         }
         ++i;
+    }
+
+    if (m_customAuth) {
+        m_customAuth->setIsPwdLocked(isPwdLocked);
     }
 }
 


### PR DESCRIPTION
原因：用户锁定状态下重启系统，pam认证回发送失败信息，从而导致lightdm认证开始的状态，不能传递给插件，
而插件切换需要lightdm开启，没有开启的话，不能切换成功

Log: 用户锁定状态下重启系统，登录框无法加载成功
Bug: https://pms.uniontech.com/bug-view-156111.html
Influence: 登录系统，插件系统