### PR TITLE
fix: 修复开启无密码登录后，登录界面待机唤醒后直接进入桌面的问题。

### DIFF
--- a/src/lightdm-deepin-greeter/greeterworker.cpp
+++ b/src/lightdm-deepin-greeter/greeterworker.cpp
@@ -182,7 +182,9 @@ void GreeterWorker::initConnections()
             endAuthentication(m_account, AT_All);
             destoryAuthentication(m_account);
         } else {
-            createAuthentication(m_model->currentUser()->name());
+            if (!m_model->currentUser()->isNoPasswordLogin()) {
+                createAuthentication(m_model->currentUser()->name());
+            }
         }
     });
     connect(m_login1Inter, &DBusLogin1Manager::SessionRemoved, this, [this] {


### PR DESCRIPTION
开启无密码登录后，待机唤醒，做了认证操作，greeter返回认证成功，登录界面做了authFinished操作直接进入桌面。已修改唤醒判断是否是无密码登录用户，待机唤醒后通过界面操作发起认证。

Log: 修复开启无密码登录后，登录界面待机唤醒后直接进入桌面的问题。
Bug: https://pms.uniontech.com/bug-view-155369.html
Influence: 无密码登录开启，在登录界面做待机和休眠操作唤醒，查看是显示登录界面。