### PR TITLE
fix: 用户锁定状态下重启系统，登录框无法加载成功。一键登录获取指纹成功，停留登录界面

### DIFF
--- a/plugins/one-key-login/login_module.h
+++ b/plugins/one-key-login/login_module.h
@@ -77,6 +77,7 @@ private:
     AuthCallbackData m_lastAuthResult;
     AuthStatus m_authStatus;
     bool m_needSendAuthType;
+    bool m_isLocked;
 };
 
 } // namespace module

--- a/src/session-widgets/auth_custom.cpp
+++ b/src/session-widgets/auth_custom.cpp
@@ -326,10 +326,13 @@ void AuthCustom::lightdmAuthStarted()
 
     QJsonObject message;
     message["CmdType"] = "StartAuth";
-    message["AuthObjectType"] = AuthObjectType::LightDM;
+    QJsonObject retDataObj;
+    retDataObj["AuthObjectType"] = AuthObjectType::LightDM;
+    message["Data"] = retDataObj;
     std::string result = m_module->onMessage(toJson(message).toStdString());
     qInfo() << "Plugin result: " << QString::fromStdString(result);
 }
+
 
 void AuthCustom::notifyAuthState(AuthCommon::AuthType authType, AuthCommon::AuthState state)
 {
@@ -341,4 +344,20 @@ void AuthCustom::notifyAuthState(AuthCommon::AuthType authType, AuthCommon::Auth
     message["AuthType"] = authType;
     message["AuthState"] = state;
     m_module->onMessage(toJson(message).toStdString());
+
+}
+
+void AuthCustom::setLimitsInfo(const QString limitsInfoStr)
+{
+    //把输密码错误五次后，是否锁定的信息传给插件
+    if (!m_module)
+        return;
+
+    QJsonObject message;
+    message["CmdType"] = "LimitsInfo";
+    QJsonObject retDataObj;
+    retDataObj["LimitsInfoStr"] = limitsInfoStr;
+    message["Data"] = retDataObj;
+    std::string result = m_module->onMessage(toJson(message).toStdString());
+    qInfo() << "Plugin result: " << QString::fromStdString(result);
 }

--- a/src/session-widgets/auth_custom.h
+++ b/src/session-widgets/auth_custom.h
@@ -45,7 +45,9 @@ public:
     inline AuthCommon::AuthType authType() const { return m_authType; }
     void sendAuthToken();
     void lightdmAuthStarted();
+
     void notifyAuthState(AuthCommon::AuthType authType, AuthCommon::AuthState state);
+    void setLimitsInfo(const QString limitsInfoStr);
 
 protected:
     bool event(QEvent *e) override;

--- a/src/session-widgets/auth_widget.cpp
+++ b/src/session-widgets/auth_widget.cpp
@@ -10,6 +10,7 @@
 #include "auth_password.h"
 #include "auth_single.h"
 #include "auth_ukey.h"
+#include "auth_custom.h"
 #include "dlineeditex.h"
 #include "framedatabind.h"
 #include "keyboardmonitor.h"
@@ -157,7 +158,7 @@ void AuthWidget::setUser(std::shared_ptr<User> user)
                      << connect(user.get(), &User::passwordHintChanged, this, &AuthWidget::setPasswordHint)
                      << connect(user.get(), &User::limitsInfoChanged, this, &AuthWidget::setLimitsInfo)
                      << connect(user.get(), &User::passwordExpiredInfoChanged, this, &AuthWidget::updatePasswordExpiredState)
-                     << connect(user.get(), &User::limitsInfoChanged, this, &AuthWidget::setLimitsInfo);
+                     << connect(user.get(), &User::limitsInfoChangedString, this, &AuthWidget::setLimitsInfoString);
 
     setAvatar(user->avatar());
     setPasswordHint(user->passwordHint());
@@ -278,6 +279,17 @@ void AuthWidget::setLimitsInfo(const QMap<int, User::LimitsInfo> *limitsInfo)
             break;
         }
         ++i;
+    }
+}
+
+/**
+ * @brief 认证设置信息发给插件
+ * @param limitsInfoStr
+ */
+void AuthWidget::setLimitsInfoString(const QString &limitsInfoStr)
+{
+    if (m_customAuth) {
+        m_customAuth->setLimitsInfo(limitsInfoStr);
     }
 }
 

--- a/src/session-widgets/auth_widget.h
+++ b/src/session-widgets/auth_widget.h
@@ -68,6 +68,7 @@ protected:
 
     void setUser(std::shared_ptr<User> user);
     void setLimitsInfo(const QMap<int, User::LimitsInfo> *limitsInfo);
+    void setLimitsInfoString(const QString &limitsInfoStr);
     void setAvatar(const QString &avatar);
     void updateUserNameLabel();
     void setPasswordHint(const QString &hint);

--- a/src/session-widgets/userinfo.cpp
+++ b/src/session-widgets/userinfo.cpp
@@ -108,6 +108,7 @@ void User::updateLimitsInfo(const QString &info)
         m_limitsInfo->insert(limitsInfoObj["flag"].toInt(), limitsInfoTmp);
     }
     emit limitsInfoChanged(m_limitsInfo);
+    Q_EMIT limitsInfoChangedString(info);
 }
 
 /**

--- a/src/session-widgets/userinfo.h
+++ b/src/session-widgets/userinfo.h
@@ -92,6 +92,7 @@ signals:
     void keyboardLayoutChanged(const QString &);
     void keyboardLayoutListChanged(const QStringList &);
     void limitsInfoChanged(const QMap<int, LimitsInfo> *);
+    void limitsInfoChangedString(const QString &);
     void localeChanged(const QString &locale);
     void loginStateChanged(const bool);
     void noPasswordLoginChanged(const bool);


### PR DESCRIPTION
原因：1,用户锁定状态下重启系统，pam认证回发送失败信息，从而导致lightdm认证开始的状态，不能传递给插件，
而插件切换需要lightdm开启，没有开启的话，不能切换成功
2,一键登录获取指纹成功，时许问题，造成用户名是空的，停留登录界面

Log: 用户锁定状态下重启系统，登录框无法加载成功. 一键登录获取指纹成功，停留登录界面
Bug: https://pms.uniontech.com/bug-view-156111.html
Bug: https://pms.uniontech.com/bug-view-153817.html
Influence: 登录系统，插件系统