### PR TITLE
fix: S3/S4之后在登录界面，指纹识别没有反应

### DIFF
--- a/src/dde-lock/lockworker.cpp
+++ b/src/dde-lock/lockworker.cpp
@@ -132,7 +132,8 @@ void LockWorker::initConnections()
             endAuthentication(m_account, AT_All);
             destoryAuthentication(m_account);
         } else {
-            createAuthentication(m_model->currentUser()->name());
+            if(m_login1SessionSelf->active())
+                createAuthentication(m_model->currentUser()->name());
         }
         emit m_model->prepareForSleep(isSleep);
     });


### PR DESCRIPTION
在一键登录超时后关闭多用户认证

Log: 修复S3/S4之后在登录界面，指纹识别没有反应
Bug: https://pms.uniontech.com/bug-view-153913.html
Influence: 休眠指纹认证