### PR TITLE
fix: 关机或切换用户界面不显示网络和其他插件按钮

### DIFF
--- a/src/widgets/controlwidget.cpp
+++ b/src/widgets/controlwidget.cpp
@@ -71,6 +71,7 @@ void ControlWidget::setModel(const SessionBaseModel *model)
 {
     m_model = model;
     setUser(model->currentUser());
+    connect(m_model, &SessionBaseModel::onStatusChanged, this, &ControlWidget::updateModuleVisible);
 }
 
 void ControlWidget::setUser(std::shared_ptr<User> user)
@@ -579,6 +580,13 @@ void ControlWidget::onItemClicked(const QString &str)
     static_cast<QAbstractButton *>(m_keyboardBtn)->setText(currentText);
     m_arrowRectWidget->hide();
     m_curUser->setKeyboardLayout(str);
+}
+
+void ControlWidget::updateModuleVisible()
+{
+    for (QWidget *moduleWidget : m_modules.values()) {
+        moduleWidget->setVisible(m_model->currentModeState() == SessionBaseModel::ModeStatus::PasswordMode);
+    }
 }
 
 bool ControlWidget::eventFilter(QObject *watched, QEvent *event)

--- a/src/widgets/controlwidget.h
+++ b/src/widgets/controlwidget.h
@@ -110,6 +110,7 @@ public slots:
     void setKeyboardType(const QString& str);
     void setKeyboardList(const QStringList& str);
     void onItemClicked(const QString& str);
+    void updateModuleVisible();
 
 protected:
     bool eventFilter(QObject *watched, QEvent *event) Q_DECL_OVERRIDE;


### PR DESCRIPTION
关机或切换用户界面不显示网络和其他插件按钮,直接打开关机界面或切换用户界面时，当前状态不是锁屏状态，避免插件根据锁屏状态显示界面时异常

Log: 修复关机界面或切换用户界面时点击网络图标不显示网络列表问题
Bug: https://pms.uniontech.com/bug-view-156803.html
Influence: 关机或切换用户界面时不显示网络插件图标