### PR TITLE
fix: 修复特定情况下锁屏密码认证界面不显示图像和用户名的问题。

### DIFF
--- a/src/session-widgets/sfa_widget.cpp
+++ b/src/session-widgets/sfa_widget.cpp
@@ -159,7 +159,7 @@ void SFAWidget::setAuthType(const int type)
         m_frameDataBind->clearValue("SFCustomAuthStatus");
         m_frameDataBind->clearValue("SFCustomAuthMsg");
 
-        // fix152437，初始化其他认证方式图像和nameLabel为影
+        // fix152437，初始化其他认证方式图像和nameLabel为隐藏
         if (!m_userAvatar->isVisible())
             m_userAvatar->setVisible(true);
         if (!m_nameLabel->isVisible())

--- a/src/session-widgets/sfa_widget.cpp
+++ b/src/session-widgets/sfa_widget.cpp
@@ -158,6 +158,14 @@ void SFAWidget::setAuthType(const int type)
         m_authButtons.remove(AT_Custom);
         m_frameDataBind->clearValue("SFCustomAuthStatus");
         m_frameDataBind->clearValue("SFCustomAuthMsg");
+
+        // fix152437，初始化其他认证方式图像和nameLabel为影
+        if (!m_userAvatar->isVisible())
+            m_userAvatar->setVisible(true);
+        if (!m_nameLabel->isVisible())
+            m_nameLabel->setVisible(true);
+        if (!m_lockButton->isVisible())
+            m_lockButton->setVisible(true);
     }
 
     if (type != AT_None || !m_customAuth || m_user->type() != User::Default) {


### PR DESCRIPTION
新建一个账户，切换到此账户后，等待dde-lock被主动拉起来，然后设置该账户为无密码登录，锁屏即可复现此现象。此现象为custom认证方式将图像和用户名显示label给隐藏，初始化其他认证方式的时候二者继续隐藏导致的问题，已在delete custom认证方式的时候判断二者状态，如果为隐藏则打开。

Log: 修复锁屏密码认证界面不显示图像和用户名的问题。
Bug: https://pms.uniontech.com/bug-view-152437.html
Influence: 暂无其他影响。