### PR TITLE
fix: 系统重启后，使用快捷键打开锁屏（或者等待一定时间自动锁屏，在唤醒），这个插件一直转圈，进入不了登录界面

### DIFF
--- a/src/session-widgets/auth_custom.cpp
+++ b/src/session-widgets/auth_custom.cpp
@@ -112,6 +112,11 @@ void AuthCustom::reset()
     m_currentAuthData = AuthCallbackData();
 }
 
+void AuthCustom::resetInit()
+{
+    if (m_module)
+        m_module->init();
+}
 
 void AuthCustom::setAuthState(const int state, const QString &result)
 {

--- a/src/session-widgets/auth_custom.h
+++ b/src/session-widgets/auth_custom.h
@@ -35,6 +35,7 @@ public:
     const SessionBaseModel *getModel() const { return m_model; }
     void initUi();
     void reset();
+    void resetInit();
     QSize contentSize() const;
 
     inline bool showAvatar() const { return m_showAvatar; };

--- a/src/session-widgets/sfa_widget.cpp
+++ b/src/session-widgets/sfa_widget.cpp
@@ -766,6 +766,7 @@ void SFAWidget::initCustomAuth()
 {
     qDebug() << Q_FUNC_INFO << "init custom auth";
     if (m_customAuth) {
+        m_customAuth->resetInit();
         return;
     }
 


### PR DESCRIPTION

Log: 修复锁屏界面登录图标卡住的问题
Bug: https://pms.uniontech.com/bug-view-157485.html
Influence: dde-lock锁屏功能