### PR TITLE
fix: 系统重启后，使用快捷键打开锁屏（或者等待一定时间自动锁屏，在唤醒），这个插件一直转圈，进入不了登录界面

### DIFF
--- a/interface/login_module_interface.h
+++ b/interface/login_module_interface.h
@@ -149,6 +149,11 @@ public:
      * @since 1.2.0
      */
     virtual std::string onMessage(const std::string &) { return "{}"; };
+
+    /**
+     * @brief 重置插件
+     */
+    virtual void reset() = 0;
 };
 
 } // namespace module

--- a/plugins/examples/login-plugins/login-basic/login_module.cpp
+++ b/plugins/examples/login-plugins/login-basic/login_module.cpp
@@ -42,6 +42,11 @@ void LoginModule::init()
     initUI();
 }
 
+void LoginModule::reset()
+{
+    init();
+}
+
 void LoginModule::initUI()
 {
     if (m_loginWidget) {

--- a/plugins/examples/login-plugins/login-basic/login_module.h
+++ b/plugins/examples/login-plugins/login-basic/login_module.h
@@ -26,6 +26,7 @@ public:
     inline QString key() const override { return objectName(); }
     inline QWidget *content() override { return m_loginWidget; }
     void setCallback(LoginCallBack *callback) override;
+    void reset() override;
 
 private:
     void initUI();

--- a/plugins/examples/login-plugins/login-complex/login_module.cpp
+++ b/plugins/examples/login-plugins/login-complex/login_module.cpp
@@ -36,6 +36,11 @@ void LoginModule::init()
     updateInfo();
 }
 
+void LoginModule::reset()
+{
+    init();
+}
+
 void LoginModule::initUI()
 {
     if (m_loginWidget) {

--- a/plugins/examples/login-plugins/login-complex/login_module.h
+++ b/plugins/examples/login-plugins/login-complex/login_module.h
@@ -36,6 +36,7 @@ public:
     inline std::string icon() const override { return "code-block"; }
     void setCallback(LoginCallBack *callback) override;
     std::string onMessage(const std::string &) override;
+    void reset() override;
 
 private:
     void initUI();

--- a/plugins/one-key-login/login_module.cpp
+++ b/plugins/one-key-login/login_module.cpp
@@ -172,6 +172,11 @@ void LoginModule::init()
     }
 }
 
+void LoginModule::reset()
+{
+    init();
+}
+
 void LoginModule::initUI()
 {
     qInfo() << Q_FUNC_INFO;

--- a/plugins/one-key-login/login_module.h
+++ b/plugins/one-key-login/login_module.h
@@ -51,6 +51,7 @@ public:
     inline LoadType loadPluginType() const override { return  m_loadPluginType;}
     void setCallback(LoginCallBack *callback) override;
     std::string onMessage(const std::string &) override;
+    void reset() override;
 
 public Q_SLOTS:
     void slotIdentifyStatus(const QString &name, const int errorCode, const QString &msg);

--- a/src/session-widgets/auth_custom.cpp
+++ b/src/session-widgets/auth_custom.cpp
@@ -106,12 +106,17 @@ void AuthCustom::initUi()
     updateConfig();
 }
 
-void AuthCustom::reset()
+void AuthCustom::resetAuth()
 {
     qInfo() << Q_FUNC_INFO << "Reset custom auth";
     m_currentAuthData = AuthCallbackData();
 }
 
+void AuthCustom::reset()
+{
+    if (m_module)
+        m_module->reset();
+}
 
 void AuthCustom::setAuthState(const int state, const QString &result)
 {
@@ -316,7 +321,7 @@ void AuthCustom::sendAuthToken()
     } else {
         qWarning() << "Current validation is not successfully";
     }
-    reset();
+    resetAuth();
 }
 
 void AuthCustom::lightdmAuthStarted()

--- a/src/session-widgets/auth_custom.h
+++ b/src/session-widgets/auth_custom.h
@@ -34,6 +34,7 @@ public:
     void setModel(const SessionBaseModel *model);
     const SessionBaseModel *getModel() const { return m_model; }
     void initUi();
+    void resetAuth();
     void reset();
     QSize contentSize() const;
 

--- a/src/session-widgets/sfa_widget.cpp
+++ b/src/session-widgets/sfa_widget.cpp
@@ -766,6 +766,7 @@ void SFAWidget::initCustomAuth()
 {
     qDebug() << Q_FUNC_INFO << "init custom auth";
     if (m_customAuth) {
+        m_customAuth->reset();
         return;
     }
 
@@ -864,7 +865,7 @@ void SFAWidget::checkAuthResult(const int type, const int state)
         }
 
         if (m_customAuth) {
-            m_customAuth->reset();
+            m_customAuth->resetAuth();
         }
     } else if (type != AT_All && state == AS_Success) {
         m_user->setLastAuthType(type);


### PR DESCRIPTION
系统启动后，dde-lock已经在运行。锁屏时，插件重置一下。

Log: 修复锁屏界面登录图标卡住的问题
Bug: https://pms.uniontech.com/bug-view-157485.html
Influence: dde-lock锁屏功能