### PR TITLE
fix: 显示重置密码界面前发送关闭插件右键菜单信号

### DIFF
--- a/src/session-widgets/lockcontent.cpp
+++ b/src/session-widgets/lockcontent.cpp
@@ -306,6 +306,9 @@ void LockContent::setMPRISEnable(const bool state)
 
 void LockContent::onNewConnection()
 {
+    // 重置密码界面显示前需要隐藏插件右键菜单，避免抢占键盘
+    Q_EMIT m_model->hidePluginMenu();
+
     // 重置密码程序启动连接成功锁屏界面才释放键盘，避免点击重置密码过程中使用快捷键切走锁屏
     if (window()->windowHandle() && window()->windowHandle()->setKeyboardGrabEnabled(false)) {
         qDebug() << "setKeyboardGrabEnabled(false) success！";

--- a/src/session-widgets/sessionbasemodel.h
+++ b/src/session-widgets/sessionbasemodel.h
@@ -213,6 +213,9 @@ signals:
     void authStateChanged(const int, const int, const QString &);
     void authTypeChanged(const int type);
 
+    // 关闭插件右键菜单信号
+    void hidePluginMenu();
+
 private:
     bool m_hasSwap;
     bool m_visible;

--- a/src/widgets/controlwidget.cpp
+++ b/src/widgets/controlwidget.cpp
@@ -231,6 +231,7 @@ void ControlWidget::initConnect()
             m_virtualKBBtn->setVisible(m_onboardBtnVisible && !m_dconfig->value("hideOnboard", false).toBool());
         }
     });
+    connect(m_model, &SessionBaseModel::hidePluginMenu, m_contextMenu, &QMenu::close);
 }
 
 void ControlWidget::addModule(module::BaseModuleInterface *module)


### PR DESCRIPTION
重置密码界面显示前需要隐藏插件右键菜单，避免抢占键盘

Log: 修复重置密码界面和网络右键菜单抢占焦点界面闪烁问题
Bug: https://pms.uniontech.com/bug-view-151533.html
Influence: 正常显示重置密码界面