### PR TITLE
fix: 登陆界面旋转角度错误

### DIFF
--- a/src/lightdm-deepin-greeter/greeter_display_wayland.cpp
+++ b/src/lightdm-deepin-greeter/greeter_display_wayland.cpp
@@ -319,7 +319,9 @@ void GreeterDisplayWayland::setOutputs()
             MonitorConfigsForUuid_v1[id].width = jsonMonitorConfig.value("Width").toInt();
             MonitorConfigsForUuid_v1[id].height = jsonMonitorConfig.value("Height").toInt();
             MonitorConfigsForUuid_v1[id].refresh_rate = jsonMonitorConfig.value("RefreshRate").toDouble();
-            MonitorConfigsForUuid_v1[id].transform = qLn(jsonMonitorConfig.value("Rotation").toInt()) / qLn(2);
+            // 使用qCeil向上取整，在klv中greeter在计算旋转角度时，rotation=8时，使用double接收计算结果为3,用int接收计算结果为2
+            // 但是写demo计算并不会有问题，暂时找不到根因，详见bug158393
+            MonitorConfigsForUuid_v1[id].transform = qCeil(qLn(jsonMonitorConfig.value("Rotation").toInt()) / qLn(2));
             MonitorConfigsForUuid_v1[id].brightness = jsonMonitorConfig.value("Brightness").toDouble();
             MonitorConfigsForUuid_v1[id].primary = jsonMonitorConfig.value("Primary").toBool();
             // 根据是否是仅单屏显示，决定是否从配置文件中读取enable属性


### PR DESCRIPTION
在计算旋转角度时，rotation=8时，使用double接收计算结果为3,用int接收计算结果为2。 写demo计算并不会有问题，暂时找不到根因使用qCeil向上取整规避问题

Log: 修复 登陆界面旋转角度错误的问题
Bug: https://pms.uniontech.com/bug-view-158393.html
Influence: 选装角度
Change-Id: I2edfa86f5f5662ba792e49e4d038d659d5a214fa