### PR TITLE
fix: 选择关机按键后保存按钮下标并同步到多屏其他界面

### DIFF
--- a/src/session-widgets/userinfo.cpp
+++ b/src/session-widgets/userinfo.cpp
@@ -323,7 +323,7 @@ void NativeUser::updateAvatar(const QString &path)
         return;
     }
 
-    if (!pathTmp.isEmpty() && QFile(pathTmp).exists() && QFile(pathTmp).size() && checkPictureCanRead(path)) {
+    if (!pathTmp.isEmpty() && QFile(pathTmp).exists() && QFile(pathTmp).size() && checkPictureCanRead(pathTmp)) {
         m_avatar = pathTmp;
     } else {
         m_avatar = DEFAULT_AVATAR;


### PR DESCRIPTION
关机界面选择按钮，在插入显示器后无法获取当前选择的按钮，使用了默认的按钮选择，两个界面不同步

Log: 修复插入显示器后关机按钮发生改变问题
Bug: https://pms.uniontech.com/bug-view-159049.html
Influence: 插拔显示器后关机界面保持选择的按钮不变