### PR TITLE
fix: 修改一键登录等待认证时间为800ms

### DIFF
--- a/plugins/one-key-login/login_module.cpp
+++ b/plugins/one-key-login/login_module.cpp
@@ -94,7 +94,7 @@ LoginModule::LoginModule(QObject *parent)
             });
         }
     }, Qt::DirectConnection);
-    m_waitAcceptSignalTimer->setInterval(2500);
+    m_waitAcceptSignalTimer->setInterval(800);
     m_waitAcceptSignalTimer->start();
 }
 


### PR DESCRIPTION
为了缩短注销等待一键登录插件转圈时间，将等待时间缩短到800ms

Log: 修改一键登录等待认证时间为800ms
Bug: https://pms.uniontech.com/bug-view-155231.html
Influence: 注销登录页面显示