### PR TITLE
fix: 修改登陆界面休眠待机后唤醒没有一键登录的问题

### DIFF
--- a/plugins/one-key-login/login_module.cpp
+++ b/plugins/one-key-login/login_module.cpp
@@ -406,7 +406,11 @@ void LoginModule::slotPrepareForSleep(bool active)
 
     if (isSessionAvtive) {
         m_isAcceptFingerprintSignal = false;
-        startCallHuaweiFingerprint();
+        sendAuthTypeToSession(AuthType::AT_Custom);
+        // 等待切换到插件认证完成后再发起多用户认证
+        QTimer::singleShot(300, this, [this] {
+            startCallHuaweiFingerprint();
+        });
         if(m_spinner)
             m_spinner->start();
         m_waitAcceptSignalTimer->start();

--- a/src/session-widgets/sfa_widget.cpp
+++ b/src/session-widgets/sfa_widget.cpp
@@ -1075,8 +1075,7 @@ void SFAWidget::onRequestChangeAuth(const int authType)
     qInfo() << Q_FUNC_INFO << "authType" << authType << "m_chooseAuthButtonBox->isEnabled()" << m_chooseAuthButtonBox->isEnabled()
                << "m_currentAuthType" << m_currentAuthType;
 
-    //当在S3/S4阶段时，会获取前一次认证的认证类型（不是AT_Custom），这时认证失败，也需要跳转到指纹认证
-    if(!m_chooseAuthButtonBox->isEnabled() || (m_currentAuthType != AT_Custom && m_model->appType() == AuthCommon::AppType::Login)) {
+    if (!m_chooseAuthButtonBox->isEnabled()) {
         return;
     }
 


### PR DESCRIPTION
在s3/s4唤醒后首先切换到插件认证，再发起多用户认证

Log: 修改登陆界面休眠待机后唤醒没有一键登录的问题
Bug: https://pms.uniontech.com/bug-view-159297.html
Influence: 登录页面