### PR TITLE
fix: 获取用户头像文件参数错误

### DIFF
--- a/src/session-widgets/userinfo.cpp
+++ b/src/session-widgets/userinfo.cpp
@@ -323,7 +323,7 @@ void NativeUser::updateAvatar(const QString &path)
         return;
     }
 
-    if (!pathTmp.isEmpty() && QFile(pathTmp).exists() && QFile(pathTmp).size() && checkPictureCanRead(path)) {
+    if (!pathTmp.isEmpty() && QFile(pathTmp).exists() && QFile(pathTmp).size() && checkPictureCanRead(pathTmp)) {
         m_avatar = pathTmp;
     } else {
         m_avatar = DEFAULT_AVATAR;


### PR DESCRIPTION
获取用户头像文件参数错误

Log: 修复关机/重启/注销确认界面用户头像不显示问题
Bug: https://pms.uniontech.com/bug-view-159475.html
Influence: 用户修改头像后切换其他用户并关机，确认界面正常显示用户头像