### PR TITLE
fix: 选择关机按键后保存按钮下标并同步到多屏其他界面

### DIFF
--- a/src/session-widgets/sessionbasemodel.cpp
+++ b/src/session-widgets/sessionbasemodel.cpp
@@ -373,6 +373,18 @@ std::shared_ptr<User> SessionBaseModel::json2User(const QString &userJson)
     return user_ptr;
 }
 
+void SessionBaseModel::setCurrentPowerBtnIndex(const int index)
+{
+    // 多屏显示时，需要记录当前屏幕选择的关机操作按键下标，并同步给另外一个屏幕
+    // 在插件新显示器时并创建界面时需要获取当前屏幕选择的按钮下标同步显示
+    if (m_currentPowerBntIndex == index) {
+        return;
+    }
+
+    m_currentPowerBntIndex = index;
+    Q_EMIT powerBtnIndexChanged(m_currentPowerBntIndex);
+}
+
 /**
  * @brief 保存当前用户信息
  *

--- a/src/session-widgets/sessionbasemodel.h
+++ b/src/session-widgets/sessionbasemodel.h
@@ -144,6 +144,9 @@ public:
 
     std::shared_ptr<User> json2User(const QString &userJson);
 
+    void setCurrentPowerBtnIndex(const int index);
+    inline int currentPowerBtnIndex() const { return m_currentPowerBntIndex;}
+
 signals:
     /* com.deepin.daemon.Accounts */
     void currentUserChanged(const std::shared_ptr<User>);
@@ -155,6 +158,7 @@ signals:
     void MFAFlagChanged(const bool);
     /* others */
     void visibleChanged(const bool);
+    void powerBtnIndexChanged(int index);
 
 public slots:
     /* com.deepin.daemon.Accounts */
@@ -233,6 +237,7 @@ private:
     bool m_isUseWayland;
     bool m_pressedPowerBtnFromLock; // 从lock界面点的power按键
     int m_userListSize = 0;
+    int m_currentPowerBntIndex = -1;
     AppType m_appType;
     QList<std::shared_ptr<User>> m_userList;
     std::shared_ptr<User> m_currentUser;

--- a/src/widgets/shutdownwidget.h
+++ b/src/widgets/shutdownwidget.h
@@ -54,7 +54,7 @@ private:
     void initUI();
     void initConnect();
     void updateTr(RoundItemButton * widget, const QString &tr);
-    void onOtherPageChanged(const QVariant &value);
+    void onPowerBtnIndexChanged(const int index);
     void enterKeyPushed();
     void enableHibernateBtn(bool enable);
     void enableSleepBtn(bool enable);
@@ -62,6 +62,7 @@ private:
 private:
     int m_index;
     bool m_switchUserEnable= false;
+    SessionBaseModel::ModeStatus m_status;
     QList<RoundItemButton *> m_btnList;
     QList<std::pair<std::function<void (QString)>, QString>> m_trList;
     SessionBaseModel* m_model;


### PR DESCRIPTION
关机界面选择按钮，在插入显示器后无法获取当前选择的按钮，使用了默认的按钮选择，两个界面不同步

Log: 修复插入显示器后关机按钮发生改变问题
Bug: https://pms.uniontech.com/bug-view-159049.html
Influence: 插拔显示器后关机界面保持选择的按钮不变