### PR TITLE
fix: 【锁屏】多用户切换场景，锁屏界面登陆图标卡住

### DIFF
--- a/plugins/one-key-login/login_module.cpp
+++ b/plugins/one-key-login/login_module.cpp
@@ -411,9 +411,12 @@ void LoginModule::slotPrepareForSleep(bool active)
         QTimer::singleShot(300, this, [this] {
             startCallHuaweiFingerprint();
         });
-        if(m_spinner)
+        if (m_spinner)
             m_spinner->start();
         m_waitAcceptSignalTimer->start();
+    } else {
+        //fix: 多用户时，第一个用户直接锁屏，然后待机唤醒，在直接切换到另一个用户时，m_login1SessionSelf没有激活，见159949
+        sendAuthTypeToSession(AT_Fingerprint);
     }
 }
 


### PR DESCRIPTION
1，uos和uos1俩个用户都是登录过了。
2，然后uos用户先直接锁屏（快捷健就行）；
3，uos用户待机，在唤醒，不登入；
4，切换到另一个用户uos1，就会出现。

Log: 多用户切换场景，锁屏界面登陆图标卡住
Bug: https://pms.uniontech.com/bug-view-159949.html
Influence: 多用户锁屏场景