### PR TITLE
chore: 提高多屏处理的安全性

### DIFF
--- a/src/app/dde-lock.cpp
+++ b/src/app/dde-lock.cpp
@@ -132,8 +132,16 @@ int main(int argc, char *argv[])
     shutdownAgent.setModel(model);
     DBusShutdownFrontService shutdownServices(&shutdownAgent);
 
-    auto createFrame = [&] (QScreen *screen, int count) -> QWidget* {
+    auto createFrame = [&] (QPointer<QScreen> screen, int count) -> QWidget* {
         LockFrame *lockFrame = new LockFrame(model);
+        // 创建Frame可能会花费数百毫秒，这个和机器性能有关，在此过程完成后，screen可能已经析构了
+        // 在wayland的环境插拔屏幕或者显卡驱动有问题时可能会出现此类问题
+        if (screen.isNull()) {
+            lockFrame->deleteLater();
+            lockFrame = nullptr;
+            qWarning() << "Screen was released when the frame was created ";
+            return nullptr;
+        }
         lockFrame->setScreen(screen, count <= 0);
         property_group->addObject(lockFrame);
         QObject::connect(lockFrame, &LockFrame::requestSwitchToUser, worker, &LockWorker::switchToUser);

--- a/src/app/lightdm-deepin-greeter.cpp
+++ b/src/app/lightdm-deepin-greeter.cpp
@@ -379,6 +379,14 @@ int main(int argc, char* argv[])
 
     auto createFrame = [&](QPointer<QScreen> screen, int count) -> QWidget * {
         LoginWindow *loginFrame = new LoginWindow(model);
+        // 创建Frame可能会花费数百毫秒，这个和机器性能有关，在此过程完成后，screen可能已经析构了
+        // 在wayland的环境插拔屏幕或者显卡驱动有问题时可能会出现此类问题
+        if (screen.isNull()) {
+            loginFrame->deleteLater();
+            loginFrame = nullptr;
+            qWarning() << "Screen was released when the frame was created ";
+            return nullptr;
+        }
         loginFrame->setScreen(screen, count <= 0);
         property_group->addObject(loginFrame);
         QObject::connect(loginFrame, &LoginWindow::requestSwitchToUser, worker, &GreeterWorker::switchToUser);


### PR DESCRIPTION
在多屏快速插拔的时候，可能会在创建frame的时候QScreen析构了，此时这个frame是没有意义的。

Log: 提高多屏处理的安全性
Task: https://pms.uniontech.com/task-view-194575.html
Influence: 多屏处理
Change-Id: Ide05d2ce39c171ecedee908bfc1603ab7beedfb0