### PR TITLE
fix: 修改登陆界面休眠待机后唤醒没有一键登录的问题

### DIFF
--- a/plugins/one-key-login/login_module.cpp
+++ b/plugins/one-key-login/login_module.cpp
@@ -413,6 +413,8 @@ void LoginModule::slotPrepareForSleep(bool active)
         });
         if (m_spinner)
             m_spinner->start();
+        // s3/s4机器认证结果返回可能比较久,所以这里设置等待结果的时间为最大2500ms保证结果一定返回了
+        m_waitAcceptSignalTimer->setInterval(2500);
         m_waitAcceptSignalTimer->start();
     } else {
         //fix: 多用户时，第一个用户直接锁屏，然后待机唤醒，在直接切换到另一个用户时，m_login1SessionSelf没有激活，见159949


### PR DESCRIPTION
在s3/s4唤醒后首先切换到插件认证，发起多用户认证，增加等待结果的时间，防止结果回来的时候已经切换到指纹页面

Log: 修改登陆界面休眠待机后唤醒没有一键登录的问题
Bug: https://pms.uniontech.com/bug-view-159297.html
Influence: 登录页面