### PR TITLE
fix(wayland): 显示器变化后界面会丢失焦点，重新设置焦点

### DIFF
--- a/src/global_util/multiscreenmanager.cpp
+++ b/src/global_util/multiscreenmanager.cpp
@@ -133,7 +133,9 @@ void MultiScreenManager::raiseContentFrame()
     for (auto it = m_frames.constBegin(); it != m_frames.constEnd(); ++it) {
         if (it.value()->property("contentVisible").toBool()) {
             it.value()->raise();
-            it.value()->setFocus();
+            if (QGuiApplication::platformName().startsWith("wayland", Qt::CaseInsensitive)) {
+                it.value()->setFocus();
+            }
             return;
         }
     }


### PR DESCRIPTION
显示器变化后界面会丢失焦点，重新设置焦点,需要根据wayland环境区分设置

Log: 修复默认复制模式下插入显示器时，无法使用左右键选择关机等按钮
Bug: https://pms.uniontech.com/bug-view-161101.html
Influence: 默认复制模式下插入显示器时，正常使用左右键选择关机等按钮