### PR TITLE
fix: double free pointer

### DIFF
--- a/src/widgets/centertopwidget.cpp
+++ b/src/widgets/centertopwidget.cpp
@@ -23,14 +23,6 @@ CenterTopWidget::CenterTopWidget(QWidget *parent)
     initUi();
 }
 
-CenterTopWidget::~CenterTopWidget()
-{
-    if (m_topTipSpacer) {
-        delete m_topTipSpacer;
-        m_topTipSpacer = nullptr;
-    }
-}
-
 void CenterTopWidget::initUi()
 {
     QVBoxLayout *layout = new QVBoxLayout;

--- a/src/widgets/centertopwidget.h
+++ b/src/widgets/centertopwidget.h
@@ -20,7 +20,6 @@ class CenterTopWidget : public QWidget
     Q_OBJECT
 public:
     explicit CenterTopWidget(QWidget *parent = nullptr);
-    ~CenterTopWidget();
     void setCurrentUser(User *user);
 
 signals:


### PR DESCRIPTION
重复释放了spacerItem指针，widget析构的时候会把所有的layout item释放掉，不能在外部释放

Log:
Task: https://pms.uniontech.com/task-view-185919.html
Influence: 屏幕插拔
Change-Id: I9d512c38302f92fad68e7fda62c3baaf2caa6584