### PR TITLE
fix: 修复klv拔插显示器出现黑屏的问题

### DIFF
--- a/src/app/dde-lock.cpp
+++ b/src/app/dde-lock.cpp
@@ -37,6 +37,8 @@ int main(int argc, char *argv[])
     app = DApplication::globalApplication(argc, argv);
 #endif
 
+    // qt默认当最后一个窗口析构后，会自动退出程序，这里设置成false，防止插拔时，没有屏幕，导致进程退出
+    QApplication::setQuitOnLastWindowClosed(false);
     //解决Qt在Retina屏幕上图片模糊问题
     QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
     app->setOrganizationName("deepin");

--- a/src/app/lightdm-deepin-greeter.cpp
+++ b/src/app/lightdm-deepin-greeter.cpp
@@ -302,6 +302,8 @@ int main(int argc, char* argv[])
     }
 
     DApplication a(argc, argv);
+    // qt默认当最后一个窗口析构后，会自动退出程序，这里设置成false，防止插拔时，没有屏幕，导致进程退出
+    QApplication::setQuitOnLastWindowClosed(false);
     QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
     qApp->setOrganizationName("deepin");
     qApp->setApplicationName("org.deepin.dde.lightdm-deepin-greeter");

--- a/src/global_util/multiscreenmanager.cpp
+++ b/src/global_util/multiscreenmanager.cpp
@@ -70,6 +70,12 @@ bool MultiScreenManager::eventFilter(QObject *watched, QEvent *event)
 void MultiScreenManager::onScreenAdded(QPointer<QScreen> screen)
 {
     qInfo() << Q_FUNC_INFO << ", is copy mode: " << m_isCopyMode << ", screen: " << screen;
+
+    // 虚拟屏幕不处理
+    if (screen.isNull() || (screen->name().isEmpty() && (screen->geometry().width() == 0 || screen->geometry().height() == 0))) {
+        return;
+    }
+
     if (!m_registerFunction) {
         return;
     }
@@ -99,6 +105,11 @@ void MultiScreenManager::onScreenAdded(QPointer<QScreen> screen)
 void MultiScreenManager::onScreenRemoved(QPointer<QScreen> screen)
 {
     qDebug() << Q_FUNC_INFO << " is copy mode: " << m_isCopyMode << ", screen: " << screen;
+    // 虚拟屏幕不处理
+    if (screen.isNull() || (screen->name().isEmpty() && (screen->geometry().width() == 0 || screen->geometry().height() == 0))) {
+        return;
+    }
+
     if (!m_registerFunction) {
         return;
     }


### PR DESCRIPTION
qt默认当没有窗口时,会自动退出程序,而插拔屏幕时,会出现没有窗口的情况,导致进程退出

Log: 修复klv拔插显示器黑屏的问题
Bug: https://pms.uniontech.com/bug-view-160127.html
Influence: 登录界面
Change-Id: I14dbd4cdb53a4cd0b5914f6955f08c8e31fd8624