### PR TITLE
fix: 修复pgv双屏同时拔掉后，再接入HDMI，锁屏崩溃的问题

### DIFF
--- a/src/app/dde-lock.cpp
+++ b/src/app/dde-lock.cpp
@@ -135,7 +135,7 @@ int main(int argc, char *argv[])
     DBusShutdownFrontService shutdownServices(&shutdownAgent);
 
     auto createFrame = [&] (QPointer<QScreen> screen, int count) -> QWidget* {
-        LockFrame *lockFrame = new LockFrame(model);
+        QPointer<LockFrame> lockFrame = new LockFrame(model);
         // 创建Frame可能会花费数百毫秒，这个和机器性能有关，在此过程完成后，screen可能已经析构了
         // 在wayland的环境插拔屏幕或者显卡驱动有问题时可能会出现此类问题
         if (screen.isNull()) {
@@ -147,11 +147,13 @@ int main(int argc, char *argv[])
         lockFrame->setScreen(screen, count <= 0);
         property_group->addObject(lockFrame);
         QObject::connect(lockFrame, &LockFrame::requestSwitchToUser, worker, &LockWorker::switchToUser);
-        QObject::connect(model, &SessionBaseModel::visibleChanged, lockFrame, [=](const bool visible) {
+        QObject::connect(model, &SessionBaseModel::visibleChanged, lockFrame, [lockFrame](const bool visible) {
             lockFrame->setVisible(visible);
-            QTimer::singleShot(300, [=]() {
-                qInfo() << "lockFrame setVisible true, update.";
-                lockFrame->update();
+            QTimer::singleShot(300, [lockFrame] {
+                if (!lockFrame.isNull()) {
+                    qInfo() << "lockFrame setVisible true, update.";
+                    lockFrame->update();
+                }
             });
         });
         QObject::connect(model, &SessionBaseModel::visibleChanged, lockFrame,[&](bool visible) {

--- a/src/global_util/multiscreenmanager.h
+++ b/src/global_util/multiscreenmanager.h
@@ -31,10 +31,16 @@ protected:
     bool eventFilter(QObject *watched, QEvent *event) override;
 
 private:
+    void dealScreenAdded(QPointer<QScreen> screen); // 添加自定义的信号和槽是为了规避直接处理qt信号导致的崩溃问题
+    void dealScreenRemoved(QPointer<QScreen> screen);
     void onScreenAdded(QPointer<QScreen> screen);
     void onScreenRemoved(QPointer<QScreen> screen);
     void raiseContentFrame();
     int getDisplayModeByConfig(const QString &config) const;
+
+signals:
+    void screenAddSignal(QPointer<QScreen> screen);
+    void screenRemoveSignal(QPointer<QScreen> screen);
 
 private slots:
     void onDisplayModeChanged(const QString &);
@@ -42,7 +48,7 @@ private slots:
 
 private:
     std::function<QWidget* (QPointer<QScreen> , int)> m_registerFunction;
-    QMap<QScreen*, QWidget*> m_frames;
+    QMap<QPointer<QScreen>, QPointer<QWidget>> m_frames;
     QTimer *m_raiseContentFrameTimer;
     SystemDisplayInter *m_systemDisplay;
     bool m_isCopyMode;


### PR DESCRIPTION
锁屏采用直接连接的方式处理屏幕插拔事件，会有一定耗时，当屏幕移除消息到来，屏幕被移除，而上层尚未处理完毕，导致 qtwayland 崩溃。

Log: 修复pgv双屏同时拔掉后，再接入HDMI，锁屏崩溃的问题
Bug: https://pms.uniontech.com/bug-view-150385.html
Influence: 锁屏界面
Change-Id: I8b7abbdb89b72c6c21089b85cbd794cf50618c5e