### PR TITLE
fix: 修改dde-lock快速输入密码无法点击

### DIFF
--- a/src/session-widgets/auth_password.cpp
+++ b/src/session-widgets/auth_password.cpp
@@ -113,6 +113,9 @@ void AuthPassword::initConnections()
             m_lineEdit->setAlert(false);
         m_authStateLabel->setVisible(!focus && m_showAuthState);
         emit focusChanged(focus);
+        if (focus) {
+            emit lineEditTextChanged(m_lineEdit->text());
+        }
     });
     connect(m_lineEdit, &DLineEditEx::textChanged, this, [this](const QString &text) {
         m_lineEdit->hideAlertMessage();

--- a/src/session-widgets/sfa_widget.cpp
+++ b/src/session-widgets/sfa_widget.cpp
@@ -907,9 +907,23 @@ void SFAWidget::replaceWidget(AuthModule *authModule)
         authModule->clearFocus();
     else
         authModule->setFocus();
-    m_lockButton->setEnabled(false);
     onRetryButtonVisibleChanged(false);
     updateBlurEffectGeometry();
+    if (m_currentAuthType == AT_PAM) {
+        if (m_singleAuth && m_singleAuth->lineEditText() == "") {
+            m_lockButton->setEnabled(false);
+        }
+    } else if (m_currentAuthType == AT_Ukey) {
+        if (m_ukeyAuth && m_ukeyAuth->lineEditText() == "") {
+            m_lockButton->setEnabled(false);
+        }
+    } else if (m_currentAuthType == AT_Password) {
+        if (m_passwordAuth && m_passwordAuth->lineEditText() == "") {
+            m_lockButton->setEnabled(false);
+        }
+    } else {
+        m_lockButton->setEnabled(false);
+    }
 }
 
 void SFAWidget::onRetryButtonVisibleChanged(bool visible)


### PR DESCRIPTION
1.快速输入密码的时候，DLineEditEx::textChanged不会发送，但是DLineEditEx::focusChanged会响应变化； 2.设置按钮状态的时候，增加一个密码输入框是否为空的判断；

Log: 解决dde-lock切换用户，快速输入密码无法激活进入桌面的按钮
Influence: 切换用户快速输入密码
Bug: https://pms.uniontech.com/bug-view-161845.html
Change-Id: I720c5a4e140fdb694ffb396a8b473b82e1f9e9fd