### PR TITLE
fix: 重置密码弹窗键盘无法输入

### DIFF
--- a/src/widgets/controlwidget.h
+++ b/src/widgets/controlwidget.h
@@ -150,6 +150,7 @@ private:
     QList<QMetaObject::Connection> m_connectionList;
     bool m_onboardBtnVisible;
     DTK_CORE_NAMESPACE::DConfig *m_dconfig;
+    bool m_doGrabKeyboard;
 };
 
 #endif // CONTROLWIDGET_H

--- a/src/widgets/fullscreenbackground.h
+++ b/src/widgets/fullscreenbackground.h
@@ -27,6 +27,8 @@ public:
 
     bool contentVisible() const;
     void setEnterEnable(bool enable);
+    static QList<FullscreenBackground*> frames() { return frameList; }
+    QWidget *content() { return m_content.data(); }
 
 public slots:
     void updateBackground(const QString &path);
@@ -38,6 +40,7 @@ public slots:
 signals:
     void contentVisibleChanged(bool contentVisible);
     void requestDisableGlobalShortcutsForWayland(bool enable);
+    void requestLockFrameHide();
 
 protected:
     void setContent(QWidget *const w);


### PR DESCRIPTION
原因：重置密码弹窗弹出的时候让锁屏释放了键盘，然后关闭了右键菜单，
右键菜单关闭的时候锁屏又抓取了键盘，导致重置密码弹窗无法获取到键盘输入
解决方案：关闭右键菜单的时候不让锁屏重新抓取键盘

Log: 修复重置密码弹窗键盘无法输入的问题
Bug: https://pms.uniontech.com/bug-view-151531.html
Influence: 重置密码弹窗
Change-Id: I7e855457aa54c1a2cab1f8e88d876d0d4a33371f