### PR TITLE
fix: special CMAKE_INSTALL_SYSCONFDIR to /etc

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -22,7 +22,7 @@ prepare() {
 
 build() {
   cd $deepin_source_name
-  cmake . -GNinja -DCMAKE_INSTALL_PREFIX=/usr
+  cmake . -GNinja -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_SYSCONFDIR=/etc
   ninja
 }
 


### PR DESCRIPTION
by default to /usr/etc

Log: