### PR TITLE
fix: 修复点击取消关机/重启后输入密码或输入密码无法登录问题

### DIFF
--- a/src/dde-lock/lockframe.cpp
+++ b/src/dde-lock/lockframe.cpp
@@ -295,13 +295,8 @@ void LockFrame::cancelShutdownInhibit(bool hideFrame)
         setContentVisible(true);
     }
 
-    if (old_visible && hideFrame) {
-        // 从lock点的power btn，不能隐藏锁屏而进入桌面
-        if (!m_model->isPressedPowerBtnFromLock()) {
-            m_model->setVisible(false);
-        }
-
-        m_model->resetPowerBtnPressedFromLock();
+    if (hideFrame) {
+        m_model->setVisible(false);
         m_model->setCurrentModeState(SessionBaseModel::PasswordMode);
     }
 }

--- a/src/session-widgets/lockcontent.cpp
+++ b/src/session-widgets/lockcontent.cpp
@@ -108,9 +108,6 @@ void LockContent::initConnections()
         emit requestEndAuthentication(m_model->currentUser()->name(), AT_All);
     });
     connect(m_controlWidget, &ControlWidget::requestShutdown, this, [ = ] {
-        if (m_model->appType() == AuthCommon::Lock)
-            m_model->powerBtnPressedFromLock();
-
         m_model->setCurrentModeState(SessionBaseModel::ModeStatus::PowerMode);
     });
     connect(m_controlWidget, &ControlWidget::requestSwitchVirtualKB, this, &LockContent::toggleVirtualKB);
@@ -383,11 +380,6 @@ void LockContent::mouseReleaseEvent(QMouseEvent *event)
         emit requestSwitchToUser(m_model->currentUser());
     }
 
-    if (m_model->currentModeState() == SessionBaseModel::ShutDownMode
-        || m_model->currentModeState() == SessionBaseModel::PowerMode) {
-        m_model->resetPowerBtnPressedFromLock();
-    }
-
     m_model->setCurrentModeState(SessionBaseModel::ModeStatus::PasswordMode);
 
     SessionBaseWindow::mouseReleaseEvent(event);
@@ -630,11 +622,6 @@ void LockContent::keyPressEvent(QKeyEvent *event)
         }
         break;
     case Qt::Key_Escape:
-        if (m_model->currentModeState() == SessionBaseModel::ShutDownMode
-            || m_model->currentModeState() == SessionBaseModel::PowerMode) {
-            m_model->resetPowerBtnPressedFromLock();
-        }
-
         if (m_model->currentModeState() == SessionBaseModel::ModeStatus::ConfirmPasswordMode) {
             m_model->setAbortConfirm(false);
             m_model->setPowerAction(SessionBaseModel::PowerAction::None);

--- a/src/session-widgets/sessionbasemodel.cpp
+++ b/src/session-widgets/sessionbasemodel.cpp
@@ -29,7 +29,6 @@ SessionBaseModel::SessionBaseModel(QObject *parent)
     , m_allowShowCustomUser(false)
     , m_SEOpen(false)
     , m_isUseWayland(QGuiApplication::platformName().startsWith("wayland", Qt::CaseInsensitive))
-    , m_pressedPowerBtnFromLock(false)
     , m_appType(AuthCommon::None)
     , m_currentUser(nullptr)
     , m_lastLogoutUser(nullptr)
@@ -239,16 +238,6 @@ void SessionBaseModel::setAllowShowCustomUser(const bool allowShowCustomUser)
         return;
 
     m_allowShowCustomUser = allowShowCustomUser;
-}
-
-void SessionBaseModel::powerBtnPressedFromLock()
-{
-    m_pressedPowerBtnFromLock = true;
-}
-
-void SessionBaseModel::resetPowerBtnPressedFromLock()
-{
-    m_pressedPowerBtnFromLock = false;
 }
 
 /**

--- a/src/session-widgets/sessionbasemodel.h
+++ b/src/session-widgets/sessionbasemodel.h
@@ -133,10 +133,6 @@ public:
     inline bool allowShowCustomUser() const { return m_allowShowCustomUser; }
     void setAllowShowCustomUser(const bool allowShowCustomUser);
 
-    inline bool isPressedPowerBtnFromLock() const { return m_pressedPowerBtnFromLock; }
-    void powerBtnPressedFromLock();
-    void resetPowerBtnPressedFromLock();
-
     inline const QList<std::shared_ptr<User>> getUserList() const { return m_users->values(); }
 
     inline const AuthProperty &getAuthProperty() const { return m_authProperty; }
@@ -235,7 +231,6 @@ private:
     bool m_allowShowCustomUser;
     bool m_SEOpen; // 保存等保开启、关闭的状态
     bool m_isUseWayland;
-    bool m_pressedPowerBtnFromLock; // 从lock界面点的power按键
     int m_userListSize = 0;
     int m_currentPowerBntIndex = -1;
     AppType m_appType;

--- a/src/widgets/warningcontent.cpp
+++ b/src/widgets/warningcontent.cpp
@@ -120,7 +120,8 @@ void WarningContent::doCancelShutdownInhibit()
 
     m_model->setIsCheckedInhibit(true);
     m_model->setPowerAction(SessionBaseModel::PowerAction::None);
-    emit m_model->cancelShutdownInhibit(true);
+    // 在关机界面点击取消时需要回到桌面，其他情况直接退回原界面
+    emit m_model->cancelShutdownInhibit(m_model->currentModeState() == SessionBaseModel::ModeStatus::ShutDownMode);
 }
 
 void WarningContent::doAccecpShutdownInhibit()
@@ -129,7 +130,6 @@ void WarningContent::doAccecpShutdownInhibit()
 
     m_model->setIsCheckedInhibit(true);
     m_model->setPowerAction(m_powerAction);
-    m_model->resetPowerBtnPressedFromLock();
     if (m_model->currentModeState() != SessionBaseModel::ModeStatus::ShutDownMode)
         emit m_model->cancelShutdownInhibit(false);
 }


### PR DESCRIPTION
在取消关机/重启时，只需要判断是否从关机界面发起的确认
从关机界面发起的确认时，点击取消回到桌面
其他情况按原操作退回原界面,不需要其他额外判断

Log: 修复切换用户界面点击电源按钮，然后关机/重启，再点击取消，锁屏界面无法输入密码或输入密码无法登录问题 
Bug: https://pms.uniontech.com/bug-view-163881.html 
Bug: https://pms.uniontech.com/bug-view-155809.html
Bug: https://pms.uniontech.com/bug-view-155137.html
Influence: 在取消关机重启退回锁屏界面时可以正常输入密码解锁
This reverts commit faecb05a83d471bfe985046cf9573b35e81b5f38.