### PR TITLE
fix: 修复在显示屏A上增加缩放注销再登录后，再锁屏后拔掉，新接入显示屏B无锁屏的问题

### DIFF
--- a/src/global_util/multiscreenmanager.cpp
+++ b/src/global_util/multiscreenmanager.cpp
@@ -94,7 +94,10 @@ void MultiScreenManager::onScreenAdded(QPointer<QScreen> screen)
     // 如果指针为空，则不加入Map中，并析构创建的全屏窗口。
     if (w && !screen.isNull()) {
         m_frames[screen] = w;
-        w->installEventFilter(this);
+        // wayland下没有屏幕时，容易导致qt崩溃
+        if (!QGuiApplication::platformName().startsWith("wayland", Qt::CaseInsensitive)) {
+            w->installEventFilter(this);
+        }
     } else if (w) {
         w->deleteLater();
     }
@@ -142,7 +145,7 @@ void MultiScreenManager::onScreenRemoved(QPointer<QScreen> screen)
 void MultiScreenManager::raiseContentFrame()
 {
     for (auto it = m_frames.constBegin(); it != m_frames.constEnd(); ++it) {
-        if (it.value()->property("contentVisible").toBool()) {
+        if (it.value() && it.value()->property("contentVisible").toBool()) {
             it.value()->raise();
             if (QGuiApplication::platformName().startsWith("wayland", Qt::CaseInsensitive)) {
                 it.value()->setFocus();


### PR DESCRIPTION
锁屏崩溃

Log: 修复在显示屏A上增加缩放注销再登录后，再锁屏后拔掉，新接入显示屏B无锁屏的问题
Bug: https://pms.uniontech.com/bug-view-163269.html
Influence: 锁屏
Change-Id: Ic534936af41c45bbd46a607a0c7c4804615e1b6e