### PR TITLE
fix: 全名显示位置错误

### DIFF
--- a/src/session-widgets/auth_widget.cpp
+++ b/src/session-widgets/auth_widget.cpp
@@ -299,7 +299,7 @@ void AuthWidget::setAvatar(const QString &avatar)
  */
 void AuthWidget::updateUserDisplayNameLabel()
 {
-    m_userNameWidget->updateDisplayName(m_user->displayName());
+    m_userNameWidget->updateFullName(m_user->fullName());
     m_userNameWidget->updateUserName(m_user->name());
 }
 
@@ -492,7 +492,6 @@ void AuthWidget::showEvent(QShowEvent *event)
     activateWindow();
     QWidget::showEvent(event);
 }
-
 
 void AuthWidget::resizeEvent(QResizeEvent *event)
 {

--- a/src/session-widgets/user_widget.cpp
+++ b/src/session-widgets/user_widget.cpp
@@ -72,7 +72,7 @@ void UserWidget::initUI()
     DConfigHelper::instance()->bind(this, SHOW_USER_NAME);
     if (DConfigHelper::instance()->getConfig(SHOW_USER_NAME, false).toBool()) {
         m_userNameWidget = new UserNameWidget(false, this);
-        m_userNameWidget->updateUserName(m_user->name());
+        m_userNameWidget->updateFullName(m_user->fullName());
         setFixedHeight(heightHint());
     }
     /* 模糊背景 */
@@ -156,7 +156,8 @@ void UserWidget::setAvatar(const QString &avatar)
  */
 void UserWidget::updateUserNameLabel()
 {
-    const QString &name = m_user->displayName();
+    const bool showUserName = DConfigHelper::instance()->getConfig(SHOW_USER_NAME, false).toBool();
+    const QString &name = showUserName ? m_user->name() : m_user->displayName();
     int nameWidth = m_displayNameLabel->fontMetrics().boundingRect(name).width();
     int labelMaxWidth = width() - 25 * 2;
 
@@ -167,7 +168,7 @@ void UserWidget::updateUserNameLabel()
         m_displayNameLabel->setText(name);
     }
     if (m_userNameWidget)
-        m_userNameWidget->updateUserName(m_user->name());
+        m_userNameWidget->updateFullName(m_user->fullName());
 }
 
 /**
@@ -241,7 +242,7 @@ void UserWidget::OnDConfigPropertyChanged(const QString &key, const QVariant &va
             m_mainLayout->insertWidget(m_mainLayout->indexOf(m_displayNameWidget) + 1, m_userNameWidget);
             m_userNameWidget->show();
             if (m_user)
-                m_userNameWidget->updateUserName(m_user->name());
+                m_userNameWidget->updateFullName(m_user->fullName());
 
         } else {
             if (m_userNameWidget) {

--- a/src/widgets/user_name_widget.h
+++ b/src/widgets/user_name_widget.h
@@ -18,15 +18,22 @@ public:
     explicit UserNameWidget(bool showDisplayName = true, QWidget *parent = nullptr);
     void initialize();
     void updateUserName(const QString &userName);
-    void updateDisplayName(const QString &displayName);
+    void updateFullName(const QString &displayName);
     int heightHint() const;
 
 public slots:
     void OnDConfigPropertyChanged(const QString &key, const QVariant &value);
 
 private:
-    Dtk::Widget::DLabel *m_userPic;              // 小人儿图标
-    Dtk::Widget::DLabel *m_userName;             // 用户名
-    Dtk::Widget::DLabel *m_displayNameLabel;     // 用户全名
-    bool m_showDisplayName;
+    void updateUserNameWidget();
+    void updateDisplayNameWidget();
+
+private:
+    Dtk::Widget::DLabel *m_userPicLabel;                 // 小人儿图标
+    Dtk::Widget::DLabel *m_fullNameLabel;                // 用户名
+    Dtk::Widget::DLabel *m_displayNameLabel;        // 用户全名
+    bool m_showUserName;                            // 是否显示账户名，记录DConfig的配置
+    bool m_showDisplayName;                         // 是否显示全名
+    QString m_fullNameStr;                          // 全名
+    QString m_userNameStr;                          // 账户名
 };


### PR DESCRIPTION
开始showUserName配置后，那么displayName显示用户名， 否则显示全名，如果全名为空，则显示用户名。

Log: 修复全名显示位置错误的问题
Task: https://pms.uniontech.com/task-view-200733.html
Influence: 显示账户名/全名
Change-Id: I16da28da57bb4c5eab60b267d0caf9f52c602cca