### PR TITLE
fix: 修复拔除HDMI，主屏显示会退出电源菜单进入桌面，导致所有系统快捷键无效的问题

### DIFF
--- a/src/global_util/multiscreenmanager.cpp
+++ b/src/global_util/multiscreenmanager.cpp
@@ -168,7 +168,7 @@ void MultiScreenManager::onDisplayModeChanged(const QString &)
         }
     } else {
         for (QScreen *screen : qApp->screens()) {
-            if (!m_frames[screen])
+            if (!m_frames.contains(screen))
                 onScreenAdded(screen);
         }
     }


### PR DESCRIPTION
处理了被释放的屏幕，导致崩溃

Log: 修复拔除HDMI，主屏显示会退出电源菜单进入桌面，导致所有系统快捷键无效的问题
Bug: https://pms.uniontech.com/bug-view-165825.html
Influence: 锁屏
Change-Id: I9ad2281b6babbe0b34d6a9500dee6b608ecdea09