### PR TITLE
fix: 将登录解锁按钮透明度设置为40%

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-dde-session-shell (0.0.0) unstable; urgency=medium
+dde-session-shell (5.5.80) unstable; urgency=medium
 
   * Initialize release
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-dde-session-shell (5.5.80) unstable; urgency=medium
+dde-session-shell (0.0.0) unstable; urgency=medium
 
   * Initialize release
 

--- a/src/session-widgets/auth_widget.cpp
+++ b/src/session-widgets/auth_widget.cpp
@@ -85,7 +85,7 @@ void AuthWidget::initUI()
     m_expiredStateLabel->setAlignment(Qt::AlignHCenter);
     m_expiredStateLabel->hide();
     /* 解锁按钮 */
-    m_lockButton = new DFloatingButton(this);
+    m_lockButton = new TransparentButton(this);
     if (m_model->appType() == Lock) {
         m_lockButton->setIcon(DStyle::SP_LockElement);
     } else {
@@ -334,6 +334,9 @@ void AuthWidget::setLockButtonType(const int type)
         lockPalette.setColor(QPalette::Highlight, ShutdownColor);
         break;
     default:
+//        QColor color = lockPalette.color(QPalette::Highlight);
+//        color.setAlpha(120);
+//        lockPalette.setColor(QPalette::Highlight, color);
         if (m_model->appType() == Login) {
             m_lockButton->setIcon(DStyle::SP_ArrowNext);
         } else {

--- a/src/session-widgets/auth_widget.cpp
+++ b/src/session-widgets/auth_widget.cpp
@@ -334,9 +334,6 @@ void AuthWidget::setLockButtonType(const int type)
         lockPalette.setColor(QPalette::Highlight, ShutdownColor);
         break;
     default:
-//        QColor color = lockPalette.color(QPalette::Highlight);
-//        color.setAlpha(120);
-//        lockPalette.setColor(QPalette::Highlight, color);
         if (m_model->appType() == Login) {
             m_lockButton->setIcon(DStyle::SP_ArrowNext);
         } else {

--- a/src/session-widgets/auth_widget.h
+++ b/src/session-widgets/auth_widget.h
@@ -51,7 +51,7 @@ protected:
         DStylePainter p(this);
         DStyleOptionButton opt;
         initStyleOption(&opt);
-        p.setOpacity(0.2);
+        p.setOpacity(0.3);
         p.drawControl(DStyle::CE_IconButton, opt);
     };
 };

--- a/src/session-widgets/auth_widget.h
+++ b/src/session-widgets/auth_widget.h
@@ -13,6 +13,7 @@
 #include <DClipEffectWidget>
 #include <DFloatingButton>
 #include <DLabel>
+#include <DStyleOptionButton>
 
 #include <QWidget>
 #include <QResizeEvent>
@@ -32,6 +33,28 @@ class SessionBaseModel;
 class UserAvatar;
 
 DWIDGET_USE_NAMESPACE
+
+class TransparentButton : public DFloatingButton
+{
+    Q_OBJECT
+
+public:
+    explicit TransparentButton(QWidget *parent = nullptr)
+        : DFloatingButton (parent) {
+
+    };
+
+protected:
+    void paintEvent(QPaintEvent *event) override {
+        Q_UNUSED(event)
+
+        DStylePainter p(this);
+        DStyleOptionButton opt;
+        initStyleOption(&opt);
+        p.setOpacity(0.2);
+        p.drawControl(DStyle::CE_IconButton, opt);
+    };
+};
 
 class AuthWidget : public QWidget
 {
@@ -97,7 +120,7 @@ protected:
     FrameDataBind *m_frameDataBind;
 
     DBlurEffectWidget *m_blurEffectWidget; // 模糊背景
-    DFloatingButton *m_lockButton;         // 解锁按钮
+    TransparentButton *m_lockButton;         // 解锁按钮
     UserAvatar *m_userAvatar;              // 用户头像
 
     DLabel *m_expiredStateLabel;           // 密码过期提示


### PR DESCRIPTION
按UI设计要求，将登录解锁按钮透明度设置为30%

Log: 按UI设计要求，将登录解锁按钮透明度设置为30%
Bug: https://pms.uniontech.com/bug-view-164811.html
Influence: 登录解锁按钮透明度设置为30%