### PR TITLE
fix: 登录解锁按钮不可用时透明度设置为40%

### DIFF
--- a/src/session-widgets/auth_widget.cpp
+++ b/src/session-widgets/auth_widget.cpp
@@ -85,7 +85,7 @@ void AuthWidget::initUI()
     m_expiredStateLabel->setAlignment(Qt::AlignHCenter);
     m_expiredStateLabel->hide();
     /* 解锁按钮 */
-    m_lockButton = new DFloatingButton(this);
+    m_lockButton = new TransparentButton(this);
     if (m_model->appType() == Lock) {
         m_lockButton->setIcon(DStyle::SP_LockElement);
     } else {
@@ -341,6 +341,10 @@ void AuthWidget::setLockButtonType(const int type)
         }
         break;
     }
+
+    // 按钮不可用时颜色还是使用活动色，然后需要40%透明
+    QColor color = lockPalette.color(QPalette::Active, QPalette::Highlight);
+    lockPalette.setColor(QPalette::Disabled, QPalette::Highlight, color);
     m_lockButton->setPalette(lockPalette);
 }
 

--- a/src/session-widgets/auth_widget.h
+++ b/src/session-widgets/auth_widget.h
@@ -13,6 +13,7 @@
 #include <DClipEffectWidget>
 #include <DFloatingButton>
 #include <DLabel>
+#include <DStyleOptionButton>
 
 #include <QWidget>
 #include <QResizeEvent>
@@ -32,6 +33,33 @@ class SessionBaseModel;
 class UserAvatar;
 
 DWIDGET_USE_NAMESPACE
+
+class TransparentButton : public DFloatingButton
+{
+    Q_OBJECT
+
+public:
+    explicit TransparentButton(QWidget *parent = nullptr)
+        : DFloatingButton (parent) {
+
+    };
+
+protected:
+    void paintEvent(QPaintEvent *event) override {
+        Q_UNUSED(event)
+
+        // 按钮不可用时颜色还是使用活动色，然后需要40%透明
+        DStylePainter p(this);
+        DStyleOptionButton opt;
+        initStyleOption(&opt);
+        if (isEnabled()) {
+            p.setOpacity(1.0);
+        } else {
+            p.setOpacity(0.4);
+        }
+        p.drawControl(DStyle::CE_IconButton, opt);
+    };
+};
 
 class AuthWidget : public QWidget
 {
@@ -97,7 +125,7 @@ protected:
     FrameDataBind *m_frameDataBind;
 
     DBlurEffectWidget *m_blurEffectWidget; // 模糊背景
-    DFloatingButton *m_lockButton;         // 解锁按钮
+    TransparentButton *m_lockButton;         // 解锁按钮
     UserAvatar *m_userAvatar;              // 用户头像
 
     DLabel *m_expiredStateLabel;           // 密码过期提示


### PR DESCRIPTION
按UI设计要求，将登录解锁按钮不可用时颜色不改变变灰还是使用活动色，并且透明度变为40%

Log: 登录解锁按钮不可用时透明度设置为40%
Bug: https://pms.uniontech.com/bug-view-164811.html
Influence: 登录解锁按钮不可用时透明度设置为40%