### PR TITLE
fix: 修复打开自动登陆，待机/休眠无法一键唤醒问题

### DIFF
--- a/src/session-widgets/sfa_widget.cpp
+++ b/src/session-widgets/sfa_widget.cpp
@@ -127,8 +127,13 @@ void SFAWidget::setAuthType(const int type)
 {
     qDebug() << Q_FUNC_INFO << "SFAWidget::setAuthType:" << type;
     int authType = type;
+    const bool useCustomAuth = m_model->appType() == AuthCommon::Lock         ||
+                             ( m_model ->appType() == AuthCommon::Login       &&
+                               !m_model->currentUser()->isNoPasswordLogin()   &&
+                               !m_model->currentUser()->isAutomaticLogin());
+
     if (dss::module::ModulesLoader::instance().findModulesByType(dss::module::BaseModuleInterface::LoginType).size() > 0
-            && !m_model->currentUser()->isNoPasswordLogin() && !m_model->currentUser()->isAutomaticLogin()) {
+            && useCustomAuth) {
         authType |= AT_Custom;
         initCustomAuth();
 


### PR DESCRIPTION
自动登陆和免密登陆不应该影响dde-lock,增加判断当前类型为lock

Log: 修复打开自动登陆，待机/休眠无法一键唤醒问题
Bug: https://pms.uniontech.com/bug-view-165877.html
Influence: 锁屏