### PR TITLE
fix: 域管环境切换用户异常

### DIFF
--- a/plugins/one-key-login/login_module.cpp
+++ b/plugins/one-key-login/login_module.cpp
@@ -279,6 +279,7 @@ std::string LoginModule::onMessage(const std::string &message)
         retDataObj["ShowLockButton"] = false;
         retDataObj["DefaultAuthLevel"] = DefaultAuthLevel::StrongDefault;
         retDataObj["AuthType"] = AuthType::AT_Custom;
+        retDataObj["SupportDefaultUser"] = false;
 
         retObj["Data"] = retDataObj;
     } else if (cmdType == "StartAuth"){

--- a/src/session-widgets/auth_custom.h
+++ b/src/session-widgets/auth_custom.h
@@ -49,6 +49,7 @@ public:
 
     void notifyAuthState(AuthCommon::AuthType authType, AuthCommon::AuthState state);
     void setLimitsInfo(const QString limitsInfoStr);
+    static bool supportDefaultUser(dss::module::LoginModuleInterface *module);
 
 protected:
     bool event(QEvent *e) override;
@@ -61,6 +62,7 @@ private:
     void updateConfig();
     void changeAuthType(AuthCommon::AuthType type);
     static AuthCustom *getAuthCustomObj(void *app_data);
+    static QJsonObject getDataObj(const QString &jsonStr);
 
 Q_SIGNALS:
     void requestCheckAccount(const QString &account);

--- a/src/session-widgets/sfa_widget.h
+++ b/src/session-widgets/sfa_widget.h
@@ -71,6 +71,7 @@ private:
     void updateSpaceItem();
     void updateFocus();
     void initAccount();
+    bool useCustomAuth() const;
 
 private:
     QVBoxLayout *m_mainLayout;


### PR DESCRIPTION
原因：切换到"..."账户的时候不应该开启一键登录插件。
修改方案：增加"SupportDefaultUser"配置，切换到"..."用户的时候判断插件是否支持； 默认认证插件是支持SupportDefaultUser的

Log: 修复域管环境切换用户异常的问题
Bug: https://pms.uniontech.com/bug-view-166349.html
Influence: 一键登录切换到"..."用户
Change-Id: I852ce9e95de80410c59d6e8da5692feead8b6bd1