### PR TITLE
fix: 初始化AuthPassword界面时设置为当前界面的FocusProxy

### DIFF
--- a/src/global_util/multiscreenmanager.cpp
+++ b/src/global_util/multiscreenmanager.cpp
@@ -59,9 +59,11 @@ void MultiScreenManager::register_for_mutil_screen(std::function<QWidget *(QScre
     }
 }
 
-void MultiScreenManager::startRaiseContentFrame()
+void MultiScreenManager::startRaiseContentFrame(const bool visible)
 {
-    m_raiseContentFrameTimer->start();
+    if (visible) {
+        m_raiseContentFrameTimer->start();
+    }
 }
 
 bool MultiScreenManager::eventFilter(QObject *watched, QEvent *event)

--- a/src/global_util/multiscreenmanager.h
+++ b/src/global_util/multiscreenmanager.h
@@ -25,7 +25,7 @@ public:
     explicit MultiScreenManager(QObject *parent = nullptr);
 
     void register_for_mutil_screen(std::function<QWidget* (QScreen *, int)> function);
-    void startRaiseContentFrame();
+    void startRaiseContentFrame(const bool visible = true);
 
 protected:
     bool eventFilter(QObject *watched, QEvent *event) override;

--- a/src/session-widgets/sfa_widget.cpp
+++ b/src/session-widgets/sfa_widget.cpp
@@ -921,6 +921,8 @@ void SFAWidget::replaceWidget(AuthModule *authModule)
     } else {
         m_lockButton->setEnabled(false);
     }
+
+    setFocusProxy(authModule);
 }
 
 void SFAWidget::onRetryButtonVisibleChanged(bool visible)


### PR DESCRIPTION
初始化AuthPassword界面时设置为当前界面的FocusProxy

Log: 修复进入系统后使用win+L快捷键锁屏时焦点不在密码框问题
Bug: https://pms.uniontech.com/bug-view-166337.html
Influence: win+L快捷键锁屏时密码框自动获得焦点