### PR TITLE
fix: 修复待机唤醒后登录框loading时间过长，耗时3-5s问题

### DIFF
--- a/plugins/one-key-login/login_module.cpp
+++ b/plugins/one-key-login/login_module.cpp
@@ -411,12 +411,11 @@ void LoginModule::slotPrepareForSleep(bool active)
         // 等待切换到插件认证完成后再发起多用户认证
         QTimer::singleShot(300, this, [this] {
             startCallHuaweiFingerprint();
+            m_waitAcceptSignalTimer->setInterval(800);
+            m_waitAcceptSignalTimer->start();
         });
         if (m_spinner)
             m_spinner->start();
-        // s3/s4机器认证结果返回可能比较久,所以这里设置等待结果的时间为最大2500ms保证结果一定返回了
-        m_waitAcceptSignalTimer->setInterval(2500);
-        m_waitAcceptSignalTimer->start();
     } else {
         //fix: 多用户时，第一个用户直接锁屏，然后待机唤醒，在直接切换到另一个用户时，m_login1SessionSelf没有激活，见159949
         sendAuthTypeToSession(AT_Fingerprint);


### PR DESCRIPTION
减少一键登录等待验证时间

Log: 修复待机唤醒后登录框loading时间过长，耗时3-5s
Bug: https://pms.uniontech.com/bug-view-166257.html
Influence: 用户须知界面展示