### PR TITLE
fix: 密码提示颜色错误

### DIFF
--- a/src/session-widgets/auth_password.h
+++ b/src/session-widgets/auth_password.h
@@ -13,6 +13,7 @@
 #include <DFloatingMessage>
 #include <DSuggestButton>
 #include <DMessageManager>
+#include <DAlertControl>
 
 #define Password_Auth QStringLiteral(":/misc/images/auth/password.svg")
 //const QString Password_Auth = ":/misc/images/auth/password.svg";
@@ -65,6 +66,8 @@ private:
     void showPasswordHint();
     void setPasswordHintBtnVisible(const bool isVisible);
     bool isUserAccountBinded();
+    void showAlertMessage(const QString &text);
+    void hidePasswordHintWidget();
 
 private:
     DLabel *m_capsLock;             // 大小写状态
@@ -75,6 +78,7 @@ private:
     DFloatingMessage *m_resetPasswordFloatingMessage;
     uid_t m_currentUid; // 当前用户uid
     QTimer *m_bindCheckTimer;
+    DAlertControl *m_passwordHintWidget;
 };
 
 #endif // AUTHPASSWORD_H


### PR DESCRIPTION
密码提示不应该显示红色，根据设置图将文字颜色改为黑色

Log: 修改密码提示颜色错误的问题
Bug: https://pms.uniontech.com/bug-view-167565.html
Influence: 密码提示文字颜色
Change-Id: I50aed50680a1ef615cb950596e9827a382ffde44