### PR TITLE
fix: 切换键盘布局的图标与列表问题

### DIFF
--- a/src/widgets/controlwidget.cpp
+++ b/src/widgets/controlwidget.cpp
@@ -102,7 +102,7 @@ void ControlWidget::initKeyboardLayoutList()
 
     const QStringList languageList = language.split(";");
     if (!languageList.isEmpty())
-        static_cast<QAbstractButton *>(m_keyboardBtn)->setText(languageList.at(0));
+        static_cast<QAbstractButton *>(m_keyboardBtn)->setText(languageList.at(0).toUpper());
 
     // 无特效模式时，让窗口圆角
     m_arrowRectWidget->setProperty("_d_radius_force", true);
@@ -557,7 +557,7 @@ void ControlWidget::setKeyboardType(const QString &str)
     if (currentText.contains("/"))
         currentText = currentText.split("/").last();
 
-    static_cast<QAbstractButton *>(m_keyboardBtn)->setText(currentText);
+    static_cast<QAbstractButton *>(m_keyboardBtn)->setText(currentText.toUpper());
 
     // 更新键盘布局列表
     m_kbLayoutListView->updateList(str);
@@ -583,7 +583,7 @@ void ControlWidget::onItemClicked(const QString &str)
     if (currentText.contains("/"))
         currentText = currentText.split("/").last();
 
-    static_cast<QAbstractButton *>(m_keyboardBtn)->setText(currentText);
+    static_cast<QAbstractButton *>(m_keyboardBtn)->setText(currentText.toUpper());
     m_arrowRectWidget->hide();
     m_curUser->setKeyboardLayout(str);
 }

--- a/src/widgets/kblayoutlistview.cpp
+++ b/src/widgets/kblayoutlistview.cpp
@@ -60,6 +60,8 @@ void KBLayoutListView::initUI()
     setViewportMargins(0, 0, 0, 0);
     setItemSpacing(0);
     setItemSize(QSize(200, 34));
+    setBackgroundType(DStyledItemDelegate::BackgroundType::ClipCornerBackground);
+    setSelectionMode(QAbstractItemView::NoSelection);
 
     QMargins itemMargins(this->itemMargins());
     itemMargins.setLeft(8);


### PR DESCRIPTION
修复切换键盘布局的图标与列表的问题

Log: 修复切换键盘布局的图标与列表的问题
Bug: https://pms.uniontech.com/bug-view-167447.html
Influence: 键盘布局
Change-Id: Ia9f69f029cd9714d19c6607a31cc8ddde8e804c6