### PR TITLE
fix: 修复已登录用户图标布局问题

### DIFF
--- a/misc/images/select.svg
+++ b/misc/images/select.svg
@@ -1,15 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="16px" height="16px" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 46.2 (44496) - http://www.bohemiancoding.com/sketch -->
-    <title>select</title>
-    <desc>Created with Sketch.</desc>
-    <defs></defs>
-    <g id="UI" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="select">
-            <path d="M8,0 C3.6,0 0,3.59334258 0,7.98520574 C0,12.3770689 3.6,15.9704115 8,15.9704115 C12.4,15.9704115 16,12.3770689 16,7.98520574 C16,3.59334258 12.4,0 8,0 L8,0 Z" id="select_active-copy-24" fill="#FFFFFF" opacity="0.800000012"></path>
-            <g transform="translate(4.000000, 4.000000)" id="Path-1112" stroke-width="1.2" stroke="#303030">
-                <polyline points="0.601182426 4.06499815 3.2576281 6.88760344 8.63650463 0"></polyline>
-            </g>
+    <title>list_select_dark</title>
+    <g id="list_select_dark" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" opacity="0.9">
+        <path d="M8,-5.32907052e-14 C3.6,-5.32907052e-14 0,3.59334258 0,7.98520574 C0,12.3770689 3.6,15.9704115 8,15.9704115 C12.4,15.9704115 16,12.3770689 16,7.98520574 C16,3.59334258 12.4,-5.32907052e-14 8,-5.32907052e-14 L8,-5.32907052e-14 Z" id="select_active-copy-24" fill="#FFFFFF"></path>
+        <g id="select" transform="translate(4.101182, 4.000000)" stroke="#303030" stroke-width="1.2">
+            <polyline id="Path-1112" points="0 4.06499815 2.65644568 6.88760344 8.0353222 0"></polyline>
         </g>
     </g>
 </svg>

--- a/src/session-widgets/user_widget.cpp
+++ b/src/session-widgets/user_widget.cpp
@@ -56,7 +56,10 @@ void UserWidget::initUI()
     m_loginState->setAccessibleName("LoginState");
     m_loginState->setPixmap(pixmap);
     m_loginState->setVisible(m_user->isLogin());
-    nameLayout->addWidget(m_loginState, 0, Qt::AlignVCenter | Qt::AlignRight);
+    QVBoxLayout *loginStateLayout = new QVBoxLayout(m_displayNameWidget);
+    loginStateLayout->addSpacing(4);
+    loginStateLayout->addWidget(m_loginState);
+    nameLayout->addLayout(loginStateLayout, 0);
 
     m_displayNameLabel->setAccessibleName("NameLabel");
     m_displayNameLabel->setTextFormat(Qt::TextFormat::PlainText);


### PR DESCRIPTION
按设计要求，已登录用户的打勾状态图标向下移动4个像素

Log: 修复已登录用户图标布局问题
Bug: https://pms.uniontech.com/bug-view-167385.html
Influence: 已登录用户图标布局
Change-Id: I404eeaf394020952a7af791de6139d5859136fd4