### PR TITLE
fix: 密码锁定状态下生物认证登陆异常

### DIFF
--- a/src/session-widgets/auth_password.cpp
+++ b/src/session-widgets/auth_password.cpp
@@ -301,6 +301,9 @@ void AuthPassword::setLimitsInfo(const LimitsInfo &info)
         setResetPasswordMessageVisible(false);
         updateResetPasswordUI();
     }
+
+    if (lockStateChanged)
+        emit notifyLockedStateChanged(m_limitsInfo->locked);
 }
 
 /**

--- a/src/session-widgets/auth_password.h
+++ b/src/session-widgets/auth_password.h
@@ -49,6 +49,7 @@ signals:
     void requestChangeFocus();                 // 切换焦点
     void requestShowKeyboardList();            // 显示键盘布局列表
     void resetPasswordMessageVisibleChanged(const bool isVisible);
+    void notifyLockedStateChanged(bool isLocked);
 
 public slots:
     void setResetPasswordMessageVisible(const bool isVisible);

--- a/src/session-widgets/sessionbasewindow.cpp
+++ b/src/session-widgets/sessionbasewindow.cpp
@@ -179,6 +179,9 @@ QSize SessionBaseWindow::getCenterContentSize()
 
 void SessionBaseWindow::resizeEvent(QResizeEvent *event)
 {
+    if (!m_centerTopWidget || !m_centerTopFrame || !m_mainLayout)
+        return;
+
     const int margin = calcCurrentHeight(LOCK_CONTENT_CENTER_LAYOUT_MARGIN);
     m_mainLayout->setContentsMargins(0, margin, 0, margin);
 
@@ -206,6 +209,9 @@ int SessionBaseWindow::calcCurrentHeight(int height) const
 
 int SessionBaseWindow::calcTopSpacing(int authWidgetTopSpacing) const
 {
+    if (!m_centerTopWidget)
+        return qMax(15, authWidgetTopSpacing - calcCurrentHeight(LOCK_CONTENT_TOP_WIDGET_HEIGHT));
+
     const int topWidgetHeight = qMax(calcCurrentHeight(LOCK_CONTENT_TOP_WIDGET_HEIGHT), m_centerTopWidget->sizeHint().height());
     return qMax(15, authWidgetTopSpacing - topWidgetHeight);
 }

--- a/src/session-widgets/sfa_widget.h
+++ b/src/session-widgets/sfa_widget.h
@@ -50,6 +50,7 @@ protected:
 
 protected Q_SLOTS:
     void updateBlurEffectGeometry();
+    void onActiveAuth(int authType);
 
 private:
     void initUI();

--- a/src/widgets/timewidget.cpp
+++ b/src/widgets/timewidget.cpp
@@ -18,6 +18,9 @@ const QStringList shortTimeFormat = { "h:mm", "hh:mm"};
 
 TimeWidget::TimeWidget(QWidget *parent)
     : QWidget(parent)
+    , m_timeLabel(nullptr)
+    , m_dateLabel(nullptr)
+    , m_refreshTimer(nullptr)
     , m_use24HourFormat(true)
 {
     QFont timeFont;

--- a/src/widgets/user_name_widget.cpp
+++ b/src/widgets/user_name_widget.cpp
@@ -87,6 +87,7 @@ void UserNameWidget::updateUserName(const QString &userName)
 
     m_userNameStr = userName;
     updateUserNameWidget();
+    updateDisplayNameWidget();
 }
 
 void UserNameWidget::updateUserNameWidget()


### PR DESCRIPTION
原因：
1.密码锁定状态下生物认证成功后会解除密码锁定的状态，此时会导致立即开启了密码验证，导致错误。
2.登录时如果密码锁定了,那么deepin-pam会拒绝开启验证,导致lightmd无法完成验证流程. 修改方案：
1.解除密码锁定后，不应该立即开启密码验证，需要判断一下当前的认证方式是否是密码验证。其它的认证方式亦然。 2.根据产品的要求,登录界面如果密码锁定了,那么禁用切换验证类型按钮.

Log: 修复密码锁定状态下生物认证登陆异常的问题
Bug: https://pms.uniontech.com/bug-view-166245.html
Influence: 密码、ukey、生物认证锁定后切换的场景
Change-Id: Iee7c3aabd509f3cc8b7b333f6ca82972333889bb