### PR TITLE
fix: 修复登录重置密码提示样式问题

### DIFF
--- a/src/session-widgets/auth_password.cpp
+++ b/src/session-widgets/auth_password.cpp
@@ -465,9 +465,11 @@ void AuthPassword::showResetPasswordMessage()
 
     QPalette pa;
     pa.setColor(QPalette::Background, QColor(247, 247, 247, 51));
+    pa.setColor(QPalette::Highlight, Qt::white);
+    pa.setColor(QPalette::HighlightedText, Qt::black);
     m_resetPasswordFloatingMessage = new DFloatingMessage(DFloatingMessage::MessageType::ResidentType);
     m_resetPasswordFloatingMessage->setPalette(pa);
-    m_resetPasswordFloatingMessage->setIcon(QIcon::fromTheme("dialog-warning"));
+    m_resetPasswordFloatingMessage->setIcon(QIcon::fromTheme("gtk-dialog-error").pixmap(20, 20));
     DSuggestButton *suggestButton = new DSuggestButton(tr("Reset Password"));
     suggestButton->setAutoDefault(true);
     m_resetPasswordFloatingMessage->setWidget(suggestButton);

--- a/src/session-widgets/auth_single.cpp
+++ b/src/session-widgets/auth_single.cpp
@@ -440,9 +440,11 @@ void AuthSingle::showResetPasswordMessage()
 
     QPalette pa;
     pa.setColor(QPalette::Background, QColor(247, 247, 247, 51));
+    pa.setColor(QPalette::Highlight, Qt::white);
+    pa.setColor(QPalette::HighlightedText, Qt::black);
     m_resetPasswordFloatingMessage = new DFloatingMessage(DFloatingMessage::MessageType::ResidentType);
     m_resetPasswordFloatingMessage->setPalette(pa);
-    m_resetPasswordFloatingMessage->setIcon(QIcon::fromTheme("dialog-warning"));
+    m_resetPasswordFloatingMessage->setIcon(QIcon::fromTheme("gtk-dialog-error").pixmap(20, 20));
     DSuggestButton *suggestButton = new DSuggestButton(tr("Reset Password"));
     suggestButton->setAutoDefault(true);
     m_resetPasswordFloatingMessage->setWidget(suggestButton);


### PR DESCRIPTION
1、去掉重置密码按钮活动色
2、重置密码的提示是使用的控件改为红色，大小改为20x20

Log: 修复登录重置密码提示样式问题
Bug: https://pms.uniontech.com/bug-view-168249.html
Influence: 登录重置密码提示样式
Change-Id: I3127a0d24dc075ff2c1f68e3cbb23c1725a113a6