### PR TITLE
fix: 登陆页面插件区域重启和切换用户时显示的大小不一样

### DIFF
--- a/src/session-widgets/mfa_widget.cpp
+++ b/src/session-widgets/mfa_widget.cpp
@@ -466,7 +466,7 @@ int MFAWidget::getTopSpacing() const
 
 void MFAWidget::resizeEvent(QResizeEvent *event)
 {
-    updateBlurEffectGeometry();
+    QTimer::singleShot(0, this, &MFAWidget::updateBlurEffectGeometry);
 
     AuthWidget::resizeEvent(event);
 }

--- a/src/session-widgets/sfa_widget.cpp
+++ b/src/session-widgets/sfa_widget.cpp
@@ -920,6 +920,8 @@ void SFAWidget::replaceWidget(AuthModule *authModule)
     }
 
     setFocusProxy(authModule);
+    // 加入事件循环中处理，否则其它控件的geometry还未设置完成，导致UI显示异常
+    QTimer::singleShot(0, this, &SFAWidget::updateBlurEffectGeometry);
 }
 
 void SFAWidget::onRetryButtonVisibleChanged(bool visible)
@@ -975,7 +977,7 @@ int SFAWidget::getTopSpacing() const
 void SFAWidget::resizeEvent(QResizeEvent *event)
 {
     updateSpaceItem();
-    updateBlurEffectGeometry();
+    QTimer::singleShot(0, this, &SFAWidget::updateBlurEffectGeometry);
 
     AuthWidget::resizeEvent(event);
 }
@@ -994,8 +996,11 @@ void SFAWidget::updateSpaceItem()
         m_bioBottomSpacingHolder->changeSize(0, 0);
         m_bioAuthStatePlaceHolder->changeSize(0, 0);
     }
-
+    // QSpacerItem 调用了changeSize后需要其所属的layout调用一下invalidate，详见是qt的说明:
+    // Note that if changeSize() is called after the spacer item has been added to a layout,
+    // it is necessary to invalidate the layout in order for the spacer item's new size to take effect.
     m_mainLayout->invalidate();
+
     emit updateParentLayout();
 }
 


### PR DESCRIPTION
在计算模糊区域的时候需要延时处理，等待其它控件移动到位后再进行计算

Log:
Bug: https://pms.uniontech.com/bug-view-166587.html Influence: 登录界面模糊区域
Change-Id: I67775f9a5f932d0f5720746f0ac536e49d5cb6f4 (cherry picked from commit f05e913d85b0d291a7f9efdfa57627a8a08feecd)