### PR TITLE
fix: 密码锁定后还能使用生物识别

### DIFF
--- a/src/session-widgets/auth_module.h
+++ b/src/session-widgets/auth_module.h
@@ -30,7 +30,7 @@ DWIDGET_USE_NAMESPACE
 using namespace DDESESSIONCC;
 
 struct LimitsInfo {
-    bool locked;        // 认证锁定状态 --- true: 锁定  false: 解锁
+    bool locked = false;        // 认证锁定状态 --- true: 锁定  false: 解锁
     uint maxTries;      // 最大重试次数
     uint numFailures;   // 失败次数，一直累加
     uint unlockSecs;    // 本次锁定总解锁时间（秒），不会随着时间推移减少

--- a/src/session-widgets/sfa_widget.cpp
+++ b/src/session-widgets/sfa_widget.cpp
@@ -234,7 +234,14 @@ void SFAWidget::setAuthType(const int type)
         m_frameDataBind->clearValue("SFSingleAuthMsg");
     }
 
-    m_chooseAuthButtonBox->setEnabled(true);
+    if (AppType::Login == m_model->appType() && m_passwordAuth) {
+        m_chooseAuthButtonBox->setEnabled(!m_passwordAuth->isLocked());
+        if (m_passwordAuth->isLocked()) {
+            m_user->setLastAuthType(AT_Password);
+            m_currentAuthType = AT_Password;
+        }
+    }
+
     const int count = m_authButtons.values().size();
     if (count > 0) {
         m_chooseAuthButtonBox->setButtonList(m_authButtons.values(), true);


### PR DESCRIPTION
现象：密码锁定后来回切换用户，可以用生物认证进行认证。
解决方案： 登录时根据密码锁定状态判断是否禁用切换认证类型。

Log: 修复密码锁定后还能使用生物识别的问题
Bug: https://pms.uniontech.com/bug-view-169337.html
Influence: 密码锁定状态切换用户
Change-Id: Id5ad9b46e32754cd6799c6cdac9bbae9a3e602a3