### PR TITLE
fix: 休眠唤醒后无法打开启动器

### DIFF
--- a/src/session-widgets/lockcontent.cpp
+++ b/src/session-widgets/lockcontent.cpp
@@ -116,7 +116,7 @@ void LockContent::initConnections()
     //刷新背景单独与onStatusChanged信号连接，避免在showEvent事件时调用onStatusChanged而重复刷新背景，减少刷新次数
     connect(m_model, &SessionBaseModel::onStatusChanged, this, &LockContent::onStatusChanged);
 
-    //在锁屏显示时，启动onborad进程，锁屏结束时结束onboard进程
+    // 在锁屏显示时，启动onborad进程，锁屏结束时结束onboard进程
     auto initVirtualKB = [&](bool hasvirtualkb) {
         if (hasvirtualkb && !m_virtualKB) {
             connect(&VirtualKBInstance::Instance(), &VirtualKBInstance::initFinished, this, [&] {


### PR DESCRIPTION
原因：部分机器的Login1SessionSelf::ActiveChanged的信号在DBusLogin1Manager::PrepareForSleep信号后面收到，导致重新开启了验证，设置了锁定状态，但其实界面并没有展示。 其它机器的信号都是ActiveChanged在前，PrepareForSleep在后。
由于这两个不是同一个dbus，目前并不知晓这两个信号有没有前后关系（PS：dbus信号顺序也是不可靠的），依赖信号的前后顺序是不合理的。 修改方案：session的active变化时判断model的visible控制量

Log: 修复休眠唤醒后无法打开启动器的问题
Bug: https://pms.uniontech.com/bug-view-162975.html
Influence: 待机唤醒后打开启动器
Change-Id: I6d2d2b7e9eca9b9695ebb5c27fcc9ea7e5ec7c01