### PR TITLE
fix: 账户名显示不全

### DIFF
--- a/src/session-widgets/auth_widget.cpp
+++ b/src/session-widgets/auth_widget.cpp
@@ -489,12 +489,6 @@ void AuthWidget::showEvent(QShowEvent *event)
     QWidget::showEvent(event);
 }
 
-void AuthWidget::resizeEvent(QResizeEvent *event)
-{
-    updateUserDisplayNameLabel();
-    QWidget::resizeEvent(event);
-}
-
 int AuthWidget::getTopSpacing() const
 {
     const int topHeight = static_cast<int>(topLevelWidget()->geometry().height() * AUTH_WIDGET_TOP_SPACING_PERCENT);

--- a/src/session-widgets/auth_widget.h
+++ b/src/session-widgets/auth_widget.h
@@ -16,7 +16,6 @@
 #include <DStyleOptionButton>
 
 #include <QWidget>
-#include <QResizeEvent>
 
 class AuthSingle;
 class AuthIris;
@@ -77,7 +76,6 @@ public:
     void setAccountErrorMsg(const QString &message);
     void syncPasswordResetPasswordVisibleChanged(const QVariant &value);
     void syncResetPasswordUI();
-    void resizeEvent(QResizeEvent *event) override;
 
 Q_SIGNALS:
     void requestCheckAccount(const QString &account);

--- a/src/widgets/user_name_widget.cpp
+++ b/src/widgets/user_name_widget.cpp
@@ -135,6 +135,14 @@ void UserNameWidget::updateDisplayNameWidget()
     }
 }
 
+void UserNameWidget::resizeEvent(QResizeEvent *event)
+{
+    updateUserNameWidget();
+    updateDisplayNameWidget();
+
+    QWidget::resizeEvent(event);
+}
+
 int UserNameWidget::heightHint() const
 {
     int height = 0;

--- a/src/widgets/user_name_widget.h
+++ b/src/widgets/user_name_widget.h
@@ -7,6 +7,7 @@
 #include "dconfig_helper.h"
 
 #include <QWidget>
+#include <QResizeEvent>
 
 #include <DLabel>
 
@@ -20,6 +21,7 @@ public:
     void updateUserName(const QString &userName);
     void updateFullName(const QString &displayName);
     int heightHint() const;
+    void resizeEvent(QResizeEvent *event) override;
 
 public slots:
     void OnDConfigPropertyChanged(const QString &key, const QVariant &value);


### PR DESCRIPTION
现象：账户名较长时（比如十个字母）显示不全
原因：获取控件的长度错误
修改方案：在父对象resize的时候重新获取控件大小，并计算文字内容是否需要"..."

Log: 修复账户名显示不全的问题
Task: https://pms.uniontech.com/task-view-213099.html
Influence: 锁屏、登录账户名显示
Change-Id: I806aa285fefab0d9c64f20301c4be5cf4dfda343