### PR TITLE
fix: 电源管理页面按钮下的文字改成T5号字

### DIFF
--- a/src/widgets/rounditembutton.cpp
+++ b/src/widgets/rounditembutton.cpp
@@ -73,7 +73,7 @@ void RoundItemButton::initUI()
     setFocusPolicy(Qt::NoFocus);
     setFixedSize(144, 164);
     setCheckable(true);
-    DFontSizeManager::instance()->bind(this, DFontSizeManager::T6);
+    DFontSizeManager::instance()->bind(this, DFontSizeManager::T5);
 }
 
 void RoundItemButton::enterEvent(QEvent* event)


### PR DESCRIPTION
根据UI设计师要求,把电源管理页面按钮下的文字可一起改成T5号字

Log: 电源管理页面按钮下的文字改成T5号字
Bug: https://pms.uniontech.com/bug-view-166353.html Influence: 电源管理页面按钮字号
Change-Id: I70e2ed425f2e2488d5df5014a782009682a8c8bb (cherry picked from commit 1584fda7c052b1221657d6614ccf45f1a03c8863)