### PR TITLE
fix: 锁屏界面无法切换验证方式

### DIFF
--- a/src/session-widgets/sfa_widget.cpp
+++ b/src/session-widgets/sfa_widget.cpp
@@ -234,6 +234,7 @@ void SFAWidget::setAuthType(const int type)
         m_frameDataBind->clearValue("SFSingleAuthMsg");
     }
 
+    m_chooseAuthButtonBox->setEnabled(true);
     if (AppType::Login == m_model->appType() && m_passwordAuth) {
         m_chooseAuthButtonBox->setEnabled(!m_passwordAuth->isLocked());
         if (m_passwordAuth->isLocked()) {


### PR DESCRIPTION
原因：人脸认证成功后禁用了切换验证类型的按钮，再次开启验证的时候没有启用
解决方案：如果是锁屏界面，开启验证的时候启用切换用户按钮

Log:
Bug: https://pms.uniontech.com/bug-view-172889.html
Influence: 锁屏界面切换按钮
Change-Id: I174ce0292f8d4cdb2e1e2cbca5aac7f416a6ae86