### PR TITLE
fix: fix library link

### DIFF
--- a/plugins/one-key-login/CMakeLists.txt
+++ b/plugins/one-key-login/CMakeLists.txt
@@ -4,6 +4,8 @@ find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Widgets REQUIRED)
 link_libraries(
     ${Qt_LIBS}
     Qt${QT_VERSION_MAJOR}::Widgets
+    ${DtkCore_LIBRARIES}
+    ${DtkWidget_LIBRARIES}
 )
 
 set(LIB_NAME one-key-login)


### PR DESCRIPTION
lost link to dtkcore and dtkwidget in one-key-login plugin

log: fix build on openSUSE