### PR TITLE
feat: 锁屏支持无密码解锁

### DIFF
--- a/src/app/dde-lock.cpp
+++ b/src/app/dde-lock.cpp
@@ -170,6 +170,7 @@ int main(int argc, char *argv[])
         if (model->isUseWayland()) {
             QObject::connect(lockFrame, &LockFrame::requestDisableGlobalShortcutsForWayland, worker, &LockWorker::disableGlobalShortcutsForWayland);
         }
+        QObject::connect(lockFrame, &LockFrame::requestCheckAccount, worker, &LockWorker::checkAccount);
 
         lockFrame->setVisible(model->visible());
         emit lockService.Visible(model->visible());

--- a/src/dde-lock/lockframe.cpp
+++ b/src/dde-lock/lockframe.cpp
@@ -72,6 +72,7 @@ LockFrame::LockFrame(SessionBaseModel *const model, QWidget *parent)
         emit requestEnableHotzone(true);
         emit authFinished();
     });
+    connect(m_lockContent, &LockContent::requestCheckAccount, this, &LockFrame::requestCheckAccount);
     connect(model, &SessionBaseModel::showUserList, this, &LockFrame::showUserList);
     connect(model, &SessionBaseModel::showLockScreen, this, &LockFrame::showLockScreen);
     connect(model, &SessionBaseModel::showShutdown, this, &LockFrame::showShutdown);

--- a/src/dde-lock/lockframe.h
+++ b/src/dde-lock/lockframe.h
@@ -41,6 +41,7 @@ signals:
     void sendTokenToAuth(const QString &account, const int authType, const QString &token);
     void requestEndAuthentication(const QString &account, const int authType);
     void authFinished();
+    void requestCheckAccount(const QString &account);
 
 public slots:
     void showUserList();

--- a/src/dde-lock/lockworker.cpp
+++ b/src/dde-lock/lockworker.cpp
@@ -542,6 +542,11 @@ void LockWorker::createAuthentication(const QString &account)
     std::shared_ptr<User> user_ptr = m_model->findUserByName(account);
     if (user_ptr) {
         user_ptr->updatePasswordExpiredInfo();
+
+        if (user_ptr->isNoPasswordLogin()) {
+            qInfo() << "User is no password login";
+            return;
+        }
     }
 
     m_account = account;
@@ -764,5 +769,15 @@ void LockWorker::disableGlobalShortcutsForWayland(const bool enable)
         }
     } else {
         qWarning() << "there is no shortcut should be enabled!";
+    }
+}
+
+void LockWorker::checkAccount(const QString &account)
+{
+    Q_UNUSED(account)
+
+    if (m_model->currentUser() && m_model->currentUser()->isNoPasswordLogin()) {
+        qInfo() << "Current user has set 'no password login' : " << account;
+        onAuthFinished();
     }
 }

--- a/src/dde-lock/lockworker.h
+++ b/src/dde-lock/lockworker.h
@@ -53,6 +53,7 @@ public slots:
     void onAuthStateChanged(const int type, const int state, const QString &message);
 
     void disableGlobalShortcutsForWayland(const bool enable);
+    void checkAccount(const QString &account);
 
 private:
     void initConnections();

--- a/src/session-widgets/userinfo.cpp
+++ b/src/session-widgets/userinfo.cpp
@@ -250,8 +250,12 @@ void NativeUser::initConnections()
 
 void NativeUser::initData()
 {
+    qInfo() << "User name: " << m_userInter->userName();
     m_isAutomaticLogin = m_userInter->automaticLogin();
     m_isNoPasswordLogin = m_userInter->noPasswdLogin();
+    qInfo() << "Is no password login: " << m_isNoPasswordLogin
+            << ", is auto login: " << m_isAutomaticLogin;
+
     m_isPasswordValid = (m_userInter->passwordStatus() == "P");
     m_isUse24HourFormat = m_userInter->use24HourFormat();
 
@@ -458,6 +462,7 @@ void NativeUser::updateName(const QString &name)
  */
 void NativeUser::updateNoPasswordLogin(const bool isNoPasswordLogin)
 {
+    qInfo() << "Update user no password login flag: " << isNoPasswordLogin;
     if (isNoPasswordLogin == m_isNoPasswordLogin) {
         return;
     }


### PR DESCRIPTION
在控制中心设置无密码登录后，锁屏不开启验证，点击解锁按钮即可进入

Log: 增加锁屏支持无密码解锁功能
Task: https://pms.uniontech.com/task-view-154325.html
Influence: 无密码登录锁屏界面
Change-Id: Icfe0bee1834aa9e822ff3d336b46329f9e9873d5