### PR TITLE
fix: 阻止待机/休眠操作，默认设置焦点到取消按钮上

### DIFF
--- a/src/widgets/inhibitwarnview.cpp
+++ b/src/widgets/inhibitwarnview.cpp
@@ -73,7 +73,7 @@ InhibitWarnView::InhibitWarnView(SessionBaseModel::PowerAction inhibitType, QWid
     m_cancelBtn->setFixedSize(ButtonWidth, ButtonHeight);
     m_cancelBtn->setCheckable(true);
     m_cancelBtn->setAutoExclusive(true);
-    m_cancelBtn->setFocusPolicy(Qt::NoFocus);
+    m_cancelBtn->setFocus();
 
     const auto ratio = devicePixelRatioF();
     QIcon icon_pix = QIcon::fromTheme(":/img/cancel_normal.svg").pixmap(m_cancelBtn->iconSize() * ratio);


### PR DESCRIPTION
待机、休眠等操作，第二次打开时焦点不在“取消”按钮上，因此点击Enter键会走后面流程

Log: 取消按钮设置焦点
Influence: 焦点设置
Bug: https://pms.uniontech.com/bug-view-171169.html