### PR TITLE
fix: 创建插件版本错误

### DIFF
--- a/src/global_util/plugin_manager/login_plugin_v1.cpp
+++ b/src/global_util/plugin_manager/login_plugin_v1.cpp
@@ -54,6 +54,7 @@ void LoginPluginV1::setAuthCallback(LoginPlugin::AuthCallbackFun func)
 {
     TO_LOGIN_PLUGIN
 
+    authCallbackFunc = func;
     m_loginCallBack.authCallbackFun = &LoginPluginV1::authCallBack;
     if (!m_loginCallBack.authCallbackFun || !m_loginCallBack.app_data) {
         qWarning() << "AuthCallbackFun or appData is null";
@@ -74,7 +75,7 @@ void LoginPluginV1::reset()
 
 void LoginPluginV1::authCallBack(const dss::module::AuthCallbackData *authData, void *appData)
 {
-    if (authCallbackFunc) {
+    if (!authCallbackFunc) {
         qWarning() << "Authentication call back function is null";
         return;
     }

--- a/src/global_util/plugin_manager/plugin_manager.cpp
+++ b/src/global_util/plugin_manager/plugin_manager.cpp
@@ -77,10 +77,10 @@ PluginBase* PluginManager::createPlugin(dss::module::BaseModuleInterface *module
 LoginPlugin* PluginManager::createLoginPlugin(dss::module::BaseModuleInterface *module, const QString &version)
 {
     qInfo() << "Meta version: " << version;
-    if (checkVersion(LoginPlugin_V2::API_VERSION, version)) {
+    if (checkVersion(version, LoginPlugin_V2::API_VERSION)) {
         qInfo() << "Create LoginPluginV2";
         return new LoginPlugin_V2::LoginPluginV2(dynamic_cast<dss::module_v2::LoginModuleInterfaceV2 *>(module));
-    } else if (checkVersion(LoginPlugin_V1::API_VERSION, version)){
+    } else if (checkVersion(version, LoginPlugin_V1::API_VERSION)){
         qInfo() << "Create LoginPluginV1";
         return new LoginPlugin_V1::LoginPluginV1(dynamic_cast<dss::module::LoginModuleInterface *>(module));
     }


### PR DESCRIPTION
1.比对版本号的函数传参传反了
2.LoginPluginV1没有设置messageCallbackFunc对象

Log:
Task: https://pms.uniontech.com/task-view-154325.html
Influence: 低版本插件兼容
Change-Id: I1c975f52c17c9f89c6d6a824710baed42754eac8