### PR TITLE
fix: 切换用户异常

### DIFF
--- a/plugins/one-key-login/login_module.h
+++ b/plugins/one-key-login/login_module.h
@@ -81,6 +81,7 @@ private:
     bool m_isLocked;
     QDBusInterface*  m_login1SessionSelf;
     bool m_IdentifyWithMultipleUserStarted;
+    bool m_loginAuthenticated;  // 登录界面是否已经验证过了
 };
 
 } // namespace module


### PR DESCRIPTION
一键登录插件判断是否启用插件的时机有误，应满足两个条件启用插件：
1. 在登录界面且未曾调用过验证接口，一键登录只在登录界面启动的时候认证一下。
2. 在锁屏界面且收到了唤醒信号

Log:
Bug: https://pms.uniontech.com/bug-view-174645.html
Influence: 登录、锁屏一键登录及切换用户功能
Change-Id: I04d7f303971114f32e66e34da93e2b4fb551b5e0