### PR TITLE
fix: 一键登录功能异常

### DIFF
--- a/plugins/one-key-login/login_module.cpp
+++ b/plugins/one-key-login/login_module.cpp
@@ -92,6 +92,7 @@ LoginModule::LoginModule(QObject *parent)
         // 将消息发送到Dbus
         QDBusConnection::systemBus().call(m);
         m_waitAcceptSignalTimer->stop();
+        m_loginAuthenticated = true;
         m_IdentifyWithMultipleUserStarted = false;
         if (!m_isAcceptFingerprintSignal) {
             // 防止刚切换指纹认证stop还没结束。
@@ -140,7 +141,6 @@ void LoginModule::initConnect()
 
 void LoginModule::startCallHuaweiFingerprint()
 {
-    m_loginAuthenticated = true;
     QDBusMessage m = QDBusMessage::createMethodCall("com.deepin.daemon.Authenticate", "/com/deepin/daemon/Authenticate/Fingerprint",
                                                                              "com.deepin.daemon.Authenticate.Fingerprint",
                                                                              "IdentifyWithMultipleUser");
@@ -392,9 +392,11 @@ void LoginModule::slotIdentifyStatus(const QString &name, const int errorCode, c
 void LoginModule::sendAuthData(AuthCallbackData& data)
 {
     if (!m_authCallback) {
-        qDebug() << Q_FUNC_INFO << "m_callbackFun is null";
+        qWarning() << Q_FUNC_INFO << "m_callbackFun is null";
         return;
     }
+
+    m_loginAuthenticated = true;
 
     if (m_spinner) {
         m_spinner->stop();


### PR DESCRIPTION
判断是否启用一键登录插件的时机有问题，不能在插件请求接口的地方修改标识位，应该在发送验证结果或者请求接口超时的时候设置

Log:
Bug: https://pms.uniontech.com/bug-view-174645.html
Influence: 登录、锁屏一键登录及切换用户功能
Change-Id: I6eb68c6744aa807c52b0d59b74de5434ede1891e