### PR TITLE
fix: 修复重置密码提示栏中的“红色感叹号”图标有锯齿问题

### DIFF
--- a/src/session-widgets/auth_password.cpp
+++ b/src/session-widgets/auth_password.cpp
@@ -11,6 +11,7 @@
 #include <DHiDPIHelper>
 #include <DLabel>
 #include <DPaletteHelper>
+#include <DDialogCloseButton>
 
 #include <QKeyEvent>
 #include <QTimer>
@@ -492,7 +493,18 @@ void AuthPassword::showResetPasswordMessage()
     pa.setColor(QPalette::HighlightedText, Qt::black);
     m_resetPasswordFloatingMessage = new DFloatingMessage(DFloatingMessage::MessageType::ResidentType);
     m_resetPasswordFloatingMessage->setPalette(pa);
-    m_resetPasswordFloatingMessage->setIcon(QIcon::fromTheme("gtk-dialog-error").pixmap(20, 20));
+    // DFloatingMessage 中未放开seticonsize接口，无法设置图标大小，使用缩放函数会造成图标锯齿
+    // 只能使用findChildren找到对应的图标控件来设置图标大小进行规避
+    // DFloatingMessage中有两个按钮一个是DIconButton,另一个是继承于DIconButton的DDialogCloseButton，需要区分
+    QList<DIconButton *> btnList = m_resetPasswordFloatingMessage->findChildren<DIconButton *>();
+    foreach (const auto iconButton, btnList) {
+        DDialogCloseButton * closeButton = qobject_cast<DDialogCloseButton *>(iconButton);
+        if (closeButton) {
+            continue;
+        }
+        iconButton->setIconSize(QSize(20, 20));
+    }
+    m_resetPasswordFloatingMessage->setIcon(QIcon::fromTheme("gtk-dialog-error"));
     DSuggestButton *suggestButton = new DSuggestButton(tr("Reset Password"));
     suggestButton->setAutoDefault(true);
     m_resetPasswordFloatingMessage->setWidget(suggestButton);

--- a/src/session-widgets/auth_single.cpp
+++ b/src/session-widgets/auth_single.cpp
@@ -8,6 +8,7 @@
 #include "dlineeditex.h"
 
 #include <DHiDPIHelper>
+#include <DDialogCloseButton>
 
 #include <QKeyEvent>
 #include <QTimer>
@@ -444,7 +445,18 @@ void AuthSingle::showResetPasswordMessage()
     pa.setColor(QPalette::HighlightedText, Qt::black);
     m_resetPasswordFloatingMessage = new DFloatingMessage(DFloatingMessage::MessageType::ResidentType);
     m_resetPasswordFloatingMessage->setPalette(pa);
-    m_resetPasswordFloatingMessage->setIcon(QIcon::fromTheme("gtk-dialog-error").pixmap(20, 20));
+    // DFloatingMessage 中未放开seticonsize接口，无法设置图标大小，使用缩放会造成图标锯齿
+    // 只能使用findChildren找到对应的图标控件来设置图标大小进行规避
+    // DFloatingMessage中有两个按钮一个是DIconButton,另一个是继承于DIconButton的DDialogCloseButton，需要区分
+    QList<DIconButton *> btnList = m_resetPasswordFloatingMessage->findChildren<DIconButton *>();
+    foreach (const auto iconButton, btnList) {
+        DDialogCloseButton * closeButton = qobject_cast<DDialogCloseButton *>(iconButton);
+        if (closeButton) {
+            continue;
+        }
+        iconButton->setIconSize(QSize(20, 20));
+    }
+    m_resetPasswordFloatingMessage->setIcon(QIcon::fromTheme("gtk-dialog-error"));
     DSuggestButton *suggestButton = new DSuggestButton(tr("Reset Password"));
     suggestButton->setAutoDefault(true);
     m_resetPasswordFloatingMessage->setWidget(suggestButton);


### PR DESCRIPTION
DFloatingMessage 中未放开seticonsize接口，无法设置图标大小，使用缩放函数会造成图标锯齿 只能使用findChildren找到对应的图标控件来设置图标大小进行规避
DFloatingMessage中有两个按钮一个是DIconButton,另一个是继承于DIconButton的 DDialogCloseButton，需要区分

Log: 修复重置密码提示栏中的“红色感叹号”图标有锯齿问题
Bug: https://pms.uniontech.com/bug-view-172899.html
Influence: 置密码提示栏中的“红色感叹号”图标无锯齿