### PR TITLE
fix: 锁屏失败时通知Xorg退出idleon状态

### DIFF
--- a/src/session-widgets/lockcontent.cpp
+++ b/src/session-widgets/lockcontent.cpp
@@ -556,6 +556,13 @@ void LockContent::tryGrabKeyboard(bool exitIfFalied)
             .arg(5000)
             .call();
 
+        DDBusSender()
+            .service("com.deepin.daemon.ScreenSaver")
+            .path("/org/freedesktop/ScreenSaver")
+            .interface("org.freedesktop.ScreenSaver")
+            .method(QString("SimulateUserActivity"))
+            .call();
+
         emit requestLockFrameHide();
         return;
     }


### PR DESCRIPTION
xorg的idleon和idleoff是成对存在，一般进入了idleon后操作鼠标或者键盘就会进入idleoff状态 但是在锁屏失败的时候，如果不操作鼠标键盘，就会一直在idleon状态，导致xorg不会再发送idleoff状态 因此增加在锁屏失败时模拟给xorg发送事件进入idleoff

Log: 锁屏失败自动进入idleoff状态
Bug: https://pms.uniontech.com/bug-view-125831.html###
Influence: 锁屏失败自动进入锁屏