### PR TITLE
fix: 根据界面宽度计算每行可以显示多少用户信息

### DIFF
--- a/src/session-widgets/lockcontent.cpp
+++ b/src/session-widgets/lockcontent.cpp
@@ -259,7 +259,7 @@ void LockContent::pushUserFrame()
     if(m_model->isServerModel())
         m_controlWidget->setUserSwitchEnable(false);
 
-    m_userListWidget->updateLayout();
+    m_userListWidget->updateLayout(width());
     setCenterContent(m_userListWidget);
 }
 

--- a/src/session-widgets/userframelist.h
+++ b/src/session-widgets/userframelist.h
@@ -28,7 +28,7 @@ public:
     explicit UserFrameList(QWidget *parent = nullptr);
     void setModel(SessionBaseModel *model);
     void setFixedSize(const QSize &size);
-    void updateLayout();
+    void updateLayout(int width);
 
 signals:
     void requestSwitchUser(std::shared_ptr<User> user);


### PR DESCRIPTION
根据界面宽度计算每行可以显示多少用户信息

Log: 修复显示方向设置为90度，切换用户界面没有适配，遮挡用户信息的问题
Bug: https://pms.uniontech.com/bug-view-174327.html
Influence: 根据界面宽度计算每行可以显示多少用户信息