### PR TITLE
fix: 开启无密码登录后锁屏界面异常

### DIFF
--- a/src/session-widgets/auth_widget.cpp
+++ b/src/session-widgets/auth_widget.cpp
@@ -148,7 +148,8 @@ void AuthWidget::setUser(std::shared_ptr<User> user)
                      << connect(user.get(), &User::displayNameChanged, this, &AuthWidget::updateUserDisplayNameLabel)
                      << connect(user.get(), &User::passwordHintChanged, this, &AuthWidget::setPasswordHint)
                      << connect(user.get(), &User::limitsInfoChanged, this, &AuthWidget::setLimitsInfo)
-                     << connect(user.get(), &User::passwordExpiredInfoChanged, this, &AuthWidget::updatePasswordExpiredState);
+                     << connect(user.get(), &User::passwordExpiredInfoChanged, this, &AuthWidget::updatePasswordExpiredState)
+                     << connect(user.get(), &User::noPasswordLoginChanged, this, &AuthWidget::onNoPasswordLoginChanged);
 
     setAvatar(user->avatar());
     setPasswordHint(user->passwordHint());
@@ -307,6 +308,12 @@ void AuthWidget::setPasswordHint(const QString &hint)
     if (m_passwordAuth) {
         m_passwordAuth->setPasswordHint(hint);
     }
+}
+
+void AuthWidget::onNoPasswordLoginChanged(bool noPassword)
+{
+    if (noPassword)
+        setAuthType(AT_None);
 }
 
 /**

--- a/src/session-widgets/auth_widget.h
+++ b/src/session-widgets/auth_widget.h
@@ -116,6 +116,7 @@ protected:
 
 protected Q_SLOTS:
     void updateBlurEffectGeometry();
+    void onNoPasswordLoginChanged(bool noPassword);
 
 protected:
     const SessionBaseModel *m_model;


### PR DESCRIPTION
用户的自动登录状态表变化时需要更新一下认证界面

Log:
Bug: https://pms.uniontech.com/bug-view-175901.html
Influence: 切换无密码登录状态、锁屏、登录
Change-Id: I31786e1d0d3970dbc968d62d350b1775e394cdc5