### PR TITLE
fix: Modify fail times to display reset password dialog

### DIFF
--- a/src/session-widgets/auth_password.cpp
+++ b/src/session-widgets/auth_password.cpp
@@ -317,8 +317,11 @@ void AuthPassword::setLimitsInfo(const LimitsInfo &info)
         updateUnlockPrompt();
 
     m_passwordHintBtn->setVisible(info.numFailures > 0 && !m_passwordHint.isEmpty());
-    if (m_limitsInfo->locked) {
-        setAuthState(AS_Locked, "Locked");
+    if (m_limitsInfo->numFailures >= 3) {
+        if (m_limitsInfo->locked) {
+            setAuthState(AS_Locked, "Locked");
+        }
+
         if (this->isVisible() && isShowResetPasswordMessage()) {
             qDebug() << "begin reset passoword";
             setResetPasswordMessageVisible(true);
@@ -462,8 +465,8 @@ void AuthPassword::setResetPasswordMessageVisible(const bool isVisible)
     if (m_resetPasswordMessageVisible == isVisible)
         return;
 
-    // 如果设置为显示重置按钮，但是实际上并没有锁定，直接退出，是是否锁定为准
-    if (isVisible && !isLocked())
+    // 如果设置为显示重置按钮，失败次数>=3次就显示重置密码 1060-24505
+    if (isVisible && m_limitsInfo && m_limitsInfo->numFailures < 3)
         return;
 
     m_resetPasswordMessageVisible = isVisible;
@@ -658,8 +661,11 @@ void AuthPassword::hideEvent(QHideEvent *event)
 void AuthPassword::showEvent(QShowEvent *event)
 {
     m_passwordHintBtn->setVisible(m_limitsInfo->numFailures > 0 && !m_passwordHint.isEmpty());
-    if (m_limitsInfo->locked) {
-        setAuthState(AS_Locked, "Locked");
+    if (m_limitsInfo->numFailures >= 3) {
+        if (m_limitsInfo->locked) {
+            setAuthState(AS_Locked, "Locked");
+        }
+
         if (isShowResetPasswordMessage()) {
             qDebug() << "begin reset passoword";
             setResetPasswordMessageVisible(true);

--- a/src/session-widgets/auth_single.cpp
+++ b/src/session-widgets/auth_single.cpp
@@ -256,7 +256,7 @@ void AuthSingle::setLimitsInfo(const LimitsInfo &info)
     const bool lockStateChanged = (info.locked != m_limitsInfo->locked);
     AuthModule::setLimitsInfo(info);
     setPasswordHintBtnVisible(info.numFailures > 0 && !m_passwordHint.isEmpty());
-    if (m_limitsInfo->locked) {
+    if (m_limitsInfo->numFailures >= 3) {
         bool isShow = lockStateChanged && this->isVisible() && QFile::exists(DEEPIN_DEEPINID_DAEMON_PATH) &&
                 QFile::exists(ResetPassword_Exe_Path) && m_currentUid <= 9999 && !IsCommunitySystem;
         if (isShow) {
@@ -366,8 +366,8 @@ void AuthSingle::setResetPasswordMessageVisible(const bool isVisible)
     if (m_resetPasswordMessageVisible == isVisible)
         return;
 
-    // 如果设置为显示重置按钮，但是实际上并没有锁定，直接退出，是是否锁定为准
-    if (isVisible && !isLocked())
+    // 如果设置为显示重置按钮，失败次数>=3次就显示重置密码:1060-24505
+    if (isVisible && m_limitsInfo && m_limitsInfo->numFailures < 3)
         return;
 
     m_resetPasswordMessageVisible = isVisible;


### PR DESCRIPTION
输入错误密码3次就展示重置密码按钮

Log: Modify fail times to display reset password dialog
Influence: 错误密码次数
Bug: https://pms.uniontech.com/bug-view-175909.html
Change-Id: I36545bdeeeb365d8fbb732ea1c951c07792e28b3