### PR TITLE
fix: 密码锁定后登录界面异常

### DIFF
--- a/plugins/one-key-login/login_module.cpp
+++ b/plugins/one-key-login/login_module.cpp
@@ -455,6 +455,13 @@ void LoginModule::sendAuthTypeToSession(AuthType type)
         m_needSendAuthType = true;
         return;
     }
+
+    // 登录界面密码锁定后只允许切换到密码认证，等待密码锁定解除后才能切换到其它认证类型
+    if (m_isLocked && m_appType == AppType::Login) {
+        qInfo() << "Password is locked and current application is greeter, change authentication type to password";
+        type = AuthType::AT_Password;
+    }
+
     // 这里主要为了防止 在发送切换信号的时候,lightdm还为开启认证，导致切换类型失败
     if (m_authStatus == AuthStatus::None && !m_isLocked && type != AuthType::AT_Custom && m_appType != AppType::Lock) {
         m_needSendAuthType = true;

--- a/src/session-widgets/sfa_widget.cpp
+++ b/src/session-widgets/sfa_widget.cpp
@@ -1102,8 +1102,8 @@ void SFAWidget::onRequestChangeAuth(const int authType)
             << ", chooseAuthButtonBox is enabled" << m_chooseAuthButtonBox->isEnabled()
             << ", current authentication type" << m_currentAuthType;
 
-    if (!m_chooseAuthButtonBox->isEnabled()) {
-        qWarning() << "Authentication button box is disabled";
+    if (authType != AuthCommon::AT_Password && !m_chooseAuthButtonBox->isEnabled()) {
+        qWarning() << "Authentication button box is disabled and authentication type is not password.";
         return;
     }
 


### PR DESCRIPTION
原因：登录界面密码锁定后会禁用切换认证类型按钮，一键登录请求切换认证类型的时候识别到按钮被禁用了会直接退出。 修改方案：如果是登录界面且密码被锁定了，可以切换到密码认证

Log:
Bug:
Influence: 登录界面密码锁定场景
Change-Id: Ic3c0ffe242fc83d03f03b807541cae6fe54f3fad