### PR TITLE
fix: 一键登录失败后无法使用指纹认证

### DIFF
--- a/plugins/one-key-login/login_module.cpp
+++ b/plugins/one-key-login/login_module.cpp
@@ -456,7 +456,7 @@ void LoginModule::sendAuthTypeToSession(AuthType type)
         return;
     }
     // 这里主要为了防止 在发送切换信号的时候,lightdm还为开启认证，导致切换类型失败
-    if (m_authStatus == AuthStatus::None && !m_isLocked && type != AuthType::AT_Custom && m_appType != AppType::Lock) {
+    if (m_authStatus != AuthStatus::Start && !m_isLocked && type != AuthType::AT_Custom && m_appType != AppType::Lock) {
         m_needSendAuthType = true;
         return;
     }


### PR DESCRIPTION
原因：sendAuthTypeToSession中m_authStatus状态判断错误。
修改方案：一键登录完成后可以发送切换认证类型请求。

Log:
Bug: https://pms.uniontech.com/bug-view-176463.html
Influence: 登陆界面指纹认证
Change-Id: If9de7340246e51392e448d272d749fe1d8d18102