### PR TITLE
fix: supportDefaultUser接口错误

### DIFF
--- a/src/global_util/plugin_manager/login_plugin.cpp
+++ b/src/global_util/plugin_manager/login_plugin.cpp
@@ -29,16 +29,15 @@ bool LoginPlugin::isPluginEnabled()
 
 bool LoginPlugin::supportDefaultUser()
 {
-    qDebug() << Q_FUNC_INFO;
+    qInfo() << Q_FUNC_INFO;
     QJsonObject message;
-    message["CmdType"] = "IsPluginEnabled";
+    message["CmdType"] = "GetConfigs";
     const QString &result = this->message(toJson(message));
-    qDebug() << "Result: " << result;
     const QJsonObject &dataObj = getDataObj(result);
-    if (dataObj.isEmpty() || !dataObj.contains("IsPluginEnabled"))
+    if (dataObj.isEmpty())
         return true;
 
-    return dataObj["IsPluginEnabled"].toBool(true);
+    return dataObj["SupportDefaultUser"].toBool(true);
 }
 
 void LoginPlugin::notifyCurrentUserChanged(const QString &userName)


### PR DESCRIPTION
重构时误将supportDefaultUser接口的代码粘贴错误

Log:
Task: https://pms.uniontech.com/task-view-227195.html
Influence: 域管账户认证插件
Change-Id: I24ac77079f28c426d1923cee6bce7c13a0a162b9