### PR TITLE
fix: 登录时根据验证结果去跳转用户

### DIFF
--- a/plugins/one-key-login/login_module.cpp
+++ b/plugins/one-key-login/login_module.cpp
@@ -331,10 +331,12 @@ QString LoginModule::message(const QString &message)
         }
     } else if (cmdType == "IsPluginEnabled") {
         QJsonObject retDataObj;
-        // 满足两个条件启用插件
+
+        // 满足以下条件启用插件：
         // 1. 在登录界面且未曾调用过验证接口，一键登录只在登录界面启动的时候认证一下。
         // 2. 在锁屏界面且收到了唤醒信号
-        const bool enable = (m_appType == AppType::Login && !m_loginAuthenticated) || (m_appType == AppType::Lock && m_acceptSleepSignal);
+        // 3. 验证通过(登录时根据验证结果去跳转用户)
+        const bool enable = (m_appType == AppType::Login && !m_loginAuthenticated) || (m_appType == AppType::Lock && m_acceptSleepSignal) || (m_appType == AppType::Login && m_lastAuthResult.result == AuthResult::Success);
         qInfo() << "Enable plugin: " << enable
                 << ", authenticated: " << m_loginAuthenticated
                 << ", accepted sleep signal: " << m_acceptSleepSignal;


### PR DESCRIPTION
原因：切换用户后一键登录插件被禁用了
修复方案：登录界面一键登录结果为成功时允许插件继续使用，便于切换用户后获取认证结果

Log:
Bug: https://pms.uniontech.com/bug-view-178219.html
Influence: 华为设备一键登录和切换用户
Change-Id: I6fcc498e6eb0748ec31a4b925649854b17b42da0