### PR TITLE
fix: 性能劣化

### DIFF
--- a/plugins/one-key-login/login_module.cpp
+++ b/plugins/one-key-login/login_module.cpp
@@ -101,6 +101,8 @@ LoginModule::LoginModule(QObject *parent)
             });
         }
     }, Qt::DirectConnection);
+
+    startCallHuaweiFingerprint();
 }
 
 LoginModule::~LoginModule()
@@ -176,12 +178,6 @@ void LoginModule::init()
         QTimer::singleShot(500, this, [this] {
             sendAuthTypeToSession(AuthType::AT_Fingerprint);
         });
-    }
-
-    static bool initialized = false;
-    if (!initialized) {
-        startCallHuaweiFingerprint();
-        initialized = true;
     }
 }
 


### PR DESCRIPTION
延后一键登录开始的时机会导致性能劣化，重新放到构造函数中处理。

Log:
Bug: https://pms.uniontech.com/bug-view-178233.html
Influence: 一键登录
Change-Id: Ib683e9bbbc8110b2fed161069281b12b072dc04c