### PR TITLE
fix: 修复设置按电源按钮时进入关机界面，锁屏界面，按电源键没有响应的问题

### DIFF
--- a/src/dde-lock/lockframe.cpp
+++ b/src/dde-lock/lockframe.cpp
@@ -81,7 +81,14 @@ LockFrame::LockFrame(SessionBaseModel *const model, QWidget *parent)
     connect(model, &SessionBaseModel::prepareForSleep, this, [ = ](bool isSleep) {
         //不管是待机还是唤醒均不响应电源按键信号
         m_enablePowerOffKey = false;
-
+        // 唤醒不需要密码时，在性能差的机器上可能会在1秒后才收到电源事件，依就会响应电源事件
+        // 或者将延时改的更长
+        //唤醒时间改为3秒后才响应电源按键信号，避免待机唤醒时响应信号，将界面切换到关机选项
+        if (!isSleep) {
+            QTimer::singleShot(3000, this, [ = ] {
+                m_enablePowerOffKey = true;
+            });
+        }
         //待机时由锁屏提供假黑屏，唤醒时显示正常界面
         model->setIsBlackMode(isSleep);
         model->setVisible(true);
@@ -92,18 +99,8 @@ LockFrame::LockFrame(SessionBaseModel *const model, QWidget *parent)
                 QGSettings powerSettings("com.deepin.dde.power", QByteArray(), this);
                 if (!powerSettings.get("sleep-lock").toBool()) {
                     m_model->setVisible(false);
-                    return;
                 }
             }
-        }
-
-        // 此处逻辑放到下面，唤醒不需要密码时，在性能差的机器上可能会在1秒后才收到电源事件，依就会响应电源事件
-        // 或者将延时改的更长
-        //唤醒1秒后才响应电源按键信号，避免待机唤醒时响应信号，将界面切换到关机选项
-        if (!isSleep) {
-            QTimer::singleShot(1000, this, [ = ] {
-                m_enablePowerOffKey = true;
-            });
         }
     } );
 


### PR DESCRIPTION
由于规避性能差的机器导致的响应电源事件问题，导致标志位没有重置

Log: 修复设置按电源按钮时进入关机界面，锁屏界面，按电源键没有响应的问题
Bug: https://pms.uniontech.com/bug-view-178685.html
Influence: 关机界面
Change-Id: Ib96f85f5c4159c77fc6a61ad9c6fb343878ed53d