### PR TITLE
fix: 重绘DIconButton的图标

### DIFF
--- a/misc/images/dss_warning.svg
+++ b/misc/images/dss_warning.svg
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="26px" height="26px" viewBox="0 0 26 26" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>icon/warning</title>
+    <defs>
+        <linearGradient x1="50%" y1="0%" x2="50%" y2="100%" id="linearGradient-1">
+            <stop stop-color="#FF674A" offset="0%"></stop>
+            <stop stop-color="#EC5783" offset="100%"></stop>
+        </linearGradient>
+        <path d="M9.99071429,0 C15.5186566,0 20,4.4782507 20,10 C20,15.5217493 15.5186566,20 9.99071429,20 C4.47205964,20 0,15.521755 0,10 C0,4.47824507 4.47205964,0 9.99071429,0 Z" id="path-2"></path>
+        <filter x="-27.5%" y="-17.5%" width="155.0%" height="155.0%" filterUnits="objectBoundingBox" id="filter-3">
+            <feOffset dx="0" dy="2" in="SourceAlpha" result="shadowOffsetOuter1"></feOffset>
+            <feGaussianBlur stdDeviation="1.5" in="shadowOffsetOuter1" result="shadowBlurOuter1"></feGaussianBlur>
+            <feColorMatrix values="0 0 0 0 1   0 0 0 0 0.443137255   0 0 0 0 0.443137255  0 0 0 0.3 0" type="matrix" in="shadowBlurOuter1"></feColorMatrix>
+        </filter>
+    </defs>
+    <g id="登录" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="登录-密码" transform="translate(-776.000000, -1015.000000)">
+            <g id="notify_withbutton" transform="translate(767.000000, 1002.000000)">
+                <g id="warning" transform="translate(12.000000, 14.000000)">
+                    <g id="Shape">
+                        <use fill="black" fill-opacity="1" filter="url(#filter-3)" xlink:href="#path-2"></use>
+                        <use fill="url(#linearGradient-1)" fill-rule="evenodd" xlink:href="#path-2"></use>
+                    </g>
+                    <path d="M9,5 L11,5 L11,11 L9,11 L9,5 Z M9,13 L11,13 L11,15 L9,15 L9,13 Z" id="Combined-Shape" fill="#FFFFFF" fill-rule="nonzero" opacity="0.900000036"></path>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/resources.qrc
+++ b/resources.qrc
@@ -27,5 +27,6 @@
         <file>misc/images/retry24.svg</file>
         <file>misc/images/password-hide.svg</file>
         <file>misc/images/password-shown.svg</file>
+        <file>misc/images/dss_warning.svg</file>
     </qresource>
 </RCC>

--- a/src/session-widgets/auth_password.cpp
+++ b/src/session-widgets/auth_password.cpp
@@ -48,6 +48,7 @@ AuthPassword::AuthPassword(QWidget *parent)
     , m_resetPasswordFloatingMessage(nullptr)
     , m_bindCheckTimer(nullptr)
     , m_passwordHintWidget(nullptr)
+    , m_iconButton(nullptr)
 {
     setObjectName(QStringLiteral("AuthPassword"));
     setAccessibleName(QStringLiteral("AuthPassword"));
@@ -513,9 +514,10 @@ void AuthPassword::showResetPasswordMessage()
         if (closeButton) {
             continue;
         }
-        iconButton->setIconSize(QSize(20, 20));
+        iconButton->installEventFilter(this);
+        m_iconButton = iconButton;
     }
-    m_resetPasswordFloatingMessage->setIcon(QIcon::fromTheme("gtk-dialog-error"));
+    m_resetPasswordFloatingMessage->setIcon(QIcon("://misc/images/dss_warning.svg"));
     DSuggestButton *suggestButton = new DSuggestButton(tr("Reset Password"));
     suggestButton->setAutoDefault(true);
     m_resetPasswordFloatingMessage->setWidget(suggestButton);
@@ -650,6 +652,21 @@ bool AuthPassword::eventFilter(QObject *watched, QEvent *event)
             return true;
         }
     }
+
+    if (watched == m_iconButton && event->type() == QEvent::Paint) {
+        QPainter painter(m_iconButton);
+        painter.setRenderHint(QPainter::Antialiasing, true);
+        painter.setRenderHint(QPainter::SmoothPixmapTransform, true);
+
+        if (!m_iconButton->icon().isNull()) {
+            QRect iconRect(0, 0, 20, 20);
+            iconRect.moveCenter(m_iconButton->rect().center());
+            m_iconButton->icon().paint(&painter, iconRect);
+        }
+
+        return true;
+    }
+
     return false;
 }
 

--- a/src/session-widgets/auth_password.h
+++ b/src/session-widgets/auth_password.h
@@ -82,6 +82,7 @@ private:
     uid_t m_currentUid; // 当前用户uid
     QTimer *m_bindCheckTimer;
     DAlertControl *m_passwordHintWidget;
+    DIconButton *m_iconButton;
 };
 
 #endif // AUTHPASSWORD_H

--- a/src/session-widgets/auth_single.cpp
+++ b/src/session-widgets/auth_single.cpp
@@ -39,6 +39,7 @@ AuthSingle::AuthSingle(QWidget *parent)
     , m_resetPasswordMessageVisible(false)
     , m_resetPasswordFloatingMessage(nullptr)
     , m_bindCheckTimer(nullptr)
+    , m_iconButton(nullptr)
 {
     setObjectName(QStringLiteral("AuthSingle"));
     setAccessibleName(QStringLiteral("AuthSingle"));
@@ -457,9 +458,10 @@ void AuthSingle::showResetPasswordMessage()
         if (closeButton) {
             continue;
         }
-        iconButton->setIconSize(QSize(20, 20));
+        iconButton->installEventFilter(this);
+        m_iconButton = iconButton;
     }
-    m_resetPasswordFloatingMessage->setIcon(QIcon::fromTheme("gtk-dialog-error"));
+    m_resetPasswordFloatingMessage->setIcon(QIcon("://misc/images/dss_warning.svg"));
     DSuggestButton *suggestButton = new DSuggestButton(tr("Reset Password"));
     suggestButton->setAutoDefault(true);
     m_resetPasswordFloatingMessage->setWidget(suggestButton);
@@ -602,6 +604,20 @@ bool AuthSingle::eventFilter(QObject *watched, QEvent *event)
 
     if (watched == this && event->type() == QEvent::Hide) {
         closeResetPasswordMessage();
+    }
+
+    if (watched == m_iconButton && event->type() == QEvent::Paint) {
+        QPainter painter(m_iconButton);
+        painter.setRenderHint(QPainter::Antialiasing, true);
+        painter.setRenderHint(QPainter::SmoothPixmapTransform, true);
+
+        if (!m_iconButton->icon().isNull()) {
+            QRect iconRect(0, 0, 20, 20);
+            iconRect.moveCenter(m_iconButton->rect().center());
+            m_iconButton->icon().paint(&painter, iconRect);
+        }
+
+        return true;
     }
 
     return false;

--- a/src/session-widgets/auth_single.h
+++ b/src/session-widgets/auth_single.h
@@ -67,6 +67,7 @@ private:
     DFloatingMessage *m_resetPasswordFloatingMessage;
     uid_t m_currentUid; // 当前用户uid
     QTimer *m_bindCheckTimer;
+    DIconButton *m_iconButton;
 };
 
 #endif // AUTHSINGLE_H


### PR DESCRIPTION
使用QIcon::paint重绘DIconButton的图标

Log: 修复屏幕缩放大于1倍时，登录或锁屏的重置密码提示栏中的“红色感叹号”图标有锯齿问题
Bug: https://pms.uniontech.com/bug-view-172899.html
Influence: 正常显示“红色感叹号”图标