### PR TITLE
fix: 开启自动登录后注销，指纹登录无响应

### DIFF
--- a/plugins/one-key-login/login_module.h
+++ b/plugins/one-key-login/login_module.h
@@ -61,6 +61,7 @@ private:
     void startCallHuaweiFingerprint();
     void sendAuthTypeToSession(AuthType type);
     void sendAuthData(AuthCallbackData& data);
+    void stopIdentify();
 
 private:
     AppDataPtr m_appData;

--- a/src/session-widgets/sfa_widget.cpp
+++ b/src/session-widgets/sfa_widget.cpp
@@ -1125,12 +1125,12 @@ void SFAWidget::onRequestChangeAuth(const int authType)
 bool SFAWidget::useCustomAuth() const
 {
     // 无密码登录或者自动登录不使用自定义认证
+    //去掉自动登录的判定，详见bug176463
     const bool isNoPasswordLoginEnabled = m_model->appType() == AuthCommon::Lock         ||
                              ( m_model ->appType() == AuthCommon::Login       &&
-                               !m_model->currentUser()->isNoPasswordLogin()   &&
-                               !m_model->currentUser()->isAutomaticLogin());
+                               !m_model->currentUser()->isNoPasswordLogin());
     if (!isNoPasswordLoginEnabled) {
-        qInfo() << "Automatic login is enabled";
+        qInfo() << "NoPassword login is enabled";
         return false;
     }
 


### PR DESCRIPTION
原因：一键登录插件在构造函数中请求认证结果，占用了指纹，导致无法使用指纹验证
修复方案：开启自动登录时，也加载插件。一键指纹登录完成后，会重新跳转到指纹认证，这时会开启指纹认证

Log:修复问题：先指纹登录，然后开启自动登录，再注销，指纹登陆无响应。
Bug: https://pms.uniontech.com/bug-view-176463.html
Influence: 华为设备一键登录