### PR TITLE
feat: 适配教育版登录锁屏水印

### DIFF
--- a/src/widgets/logowidget.cpp
+++ b/src/widgets/logowidget.cpp
@@ -112,6 +112,9 @@ QString LogoWidget::getVersion()
 void LogoWidget::updateLocale(const QString &locale)
 {
     m_locale = locale;
+    if(DSysInfo::UosEdition::UosEducation == DSysInfo::uosEditionType()) {  //教育版登录界面不要显示系统版本号（和Logo冲突）
+        return;
+    }
     m_logoVersionLabel->setText(getVersion());
 }
 


### PR DESCRIPTION
增加教育版判断,移除20E的文字显示

Log: 适配教育版登录锁屏水印
Task: https://pms.uniontech.com/task-view-229689.html
Influence: 登录锁屏水印
Change-Id: I17b5b22eba631bbe3a44fccd51f0237d5989e50c