### PR TITLE
feat: 密码过期后密码权限的修改

### DIFF
--- a/configs/org.deepin.dde.lightdm-deepin-greeter.json
+++ b/configs/org.deepin.dde.lightdm-deepin-greeter.json
@@ -101,6 +101,16 @@
             "description": "锁屏是否展示用户名，默认不展示",
             "permissions": "readwrite",
             "visibility": "private"
+        },
+        "changePasswordForNormalUser":{
+            "value": true,
+            "serial": 0,
+            "flags": ["global"],
+            "name": "changePasswordForNormalUser",
+            "name[zh_CN]": "密码过期后普通用户是否可以在登录界面修改密码",
+            "description": "密码过期后普通用户是否可以在登录界面修改密码，默认允许",
+            "permissions": "readwrite",
+            "visibility": "private"
         }
     }
 }

--- a/src/global_util/constants.h
+++ b/src/global_util/constants.h
@@ -70,6 +70,7 @@ const QString ENABLE_SHORTCUT_FOR_LOCK = "enableShortcutForLock";
 const QString SHOW_TOP_TIP = "showTopTip";
 const QString TOP_TIP_TEXT = "topTipText";
 const QString SHOW_USER_NAME = "showUserName";
+const QString CHANGE_PASSWORD_FOR_NORMAL_USER = "changePasswordForNormalUser";
 
 }
 

--- a/src/lightdm-deepin-greeter/greeterworker.cpp
+++ b/src/lightdm-deepin-greeter/greeterworker.cpp
@@ -503,6 +503,10 @@ void GreeterWorker::destoryAuthentication(const QString &account)
  */
 void GreeterWorker::startAuthentication(const QString &account, const int authType)
 {
+    if (!m_model->currentUser()->allowToChangePassword()) {
+        qInfo() << "Authentication exit because of user's authority";
+        return;
+    }
     qDebug() << "GreeterWorker::startAuthentication:" << account << authType;
     switch (m_model->getAuthProperty().FrameworkState) {
     case Available:

--- a/src/session-widgets/auth_password.cpp
+++ b/src/session-widgets/auth_password.cpp
@@ -400,15 +400,28 @@ QString AuthPassword::lineEditText() const
  */
 void AuthPassword::setLineEditEnabled(const bool enable)
 {
-    if (enable && !m_limitsInfo->locked) {
+    if (!m_passwordLineEditEnabled) {
+        m_lineEdit->setFocusPolicy(Qt::NoFocus);
+        m_lineEdit->clearFocus();
+        m_lineEdit->lineEdit()->setReadOnly(true);
+        m_lineEdit->lineEdit()->setEnabled(false);
+    } else if (enable && !m_limitsInfo->locked) {
         m_lineEdit->setFocusPolicy(Qt::StrongFocus);
         m_lineEdit->setFocus();
         m_lineEdit->lineEdit()->setReadOnly(false);
+        m_lineEdit->lineEdit()->setEnabled(true);
     } else {
         m_lineEdit->setFocusPolicy(Qt::NoFocus);
         m_lineEdit->clearFocus();
         m_lineEdit->lineEdit()->setReadOnly(true);
+        m_lineEdit->lineEdit()->setEnabled(true);
     }
+}
+
+void AuthPassword::setPasswordLineEditEnabled(const bool enable)
+{
+    m_passwordLineEditEnabled = enable;
+    setLineEditEnabled(enable);
 }
 
 /**

--- a/src/session-widgets/auth_password.h
+++ b/src/session-widgets/auth_password.h
@@ -30,6 +30,9 @@ public:
     void reset();
     QString lineEditText() const;
 
+    inline bool passwordLineEditEnabled() const { return m_passwordLineEditEnabled; }
+    void setPasswordLineEditEnabled(const bool enable);
+
     void setAnimationState(const bool start) override;
     void setAuthState(const int state, const QString &result) override;
     void setCapsLockVisible(const bool on);
@@ -72,6 +75,7 @@ private:
     void updatePasswordTextMargins();
 
 private:
+    bool m_passwordLineEditEnabled;
     DLabel *m_capsLock;             // 大小写状态
     DLineEditEx *m_lineEdit;        // 密码输入框
     DIconButton *m_passwordShowBtn; // 密码显示按钮

--- a/src/session-widgets/auth_single.cpp
+++ b/src/session-widgets/auth_single.cpp
@@ -281,15 +281,28 @@ void AuthSingle::setLimitsInfo(const LimitsInfo &info)
 void AuthSingle::setLineEditEnabled(const bool enable)
 {
     // m_lineEdit->setEnabled(enable);
-    if (enable) {
+    if (!m_passwordLineEditEnabled) {
+        m_lineEdit->setFocusPolicy(Qt::NoFocus);
+        m_lineEdit->clearFocus();
+        m_lineEdit->lineEdit()->setReadOnly(true);
+        m_lineEdit->lineEdit()->setEnabled(false);
+    } else if (enable) {
         m_lineEdit->setFocusPolicy(Qt::StrongFocus);
         m_lineEdit->setFocus();
         m_lineEdit->lineEdit()->setReadOnly(false);
+        m_lineEdit->lineEdit()->setEnabled(true);
     } else {
         m_lineEdit->setFocusPolicy(Qt::NoFocus);
         m_lineEdit->clearFocus();
         m_lineEdit->lineEdit()->setReadOnly(true);
+        m_lineEdit->lineEdit()->setEnabled(true);
     }
+}
+
+void AuthSingle::setPasswordLineEditEnabled(const bool enable)
+{
+    m_passwordLineEditEnabled = enable;
+    setLineEditEnabled(enable);
 }
 
 /**

--- a/src/session-widgets/auth_single.h
+++ b/src/session-widgets/auth_single.h
@@ -23,6 +23,9 @@ public:
     void reset();
     QString lineEditText() const;
 
+    inline bool passwordLineEditEnabled() const { return m_passwordLineEditEnabled; }
+    void setPasswordLineEditEnabled(const bool enable);
+
     void setAnimationState(const bool start) override;
     void setAuthState(const int state, const QString &result) override;
     void setCapsLockVisible(const bool on);
@@ -58,6 +61,7 @@ private:
     void updatePasswordTextMargins();
 
 private:
+    bool m_passwordLineEditEnabled;
     DLabel *m_capsLock;             // 大小写状态
     DLineEditEx *m_lineEdit;        // 输入框
     DPushButton *m_keyboardBtn;     // 键盘布局按钮

--- a/src/session-widgets/auth_widget.cpp
+++ b/src/session-widgets/auth_widget.cpp
@@ -388,12 +388,18 @@ void AuthWidget::updatePasswordExpiredState()
         m_expiredSpacerItem->changeSize(0, EXPIRED_SPACER_ITEM_HEIGHT);
         break;
     case User::ExpiredAlready:
-        m_expiredStateLabel->setText(tr("Password expired, please change"));
+        m_expiredStateLabel->setText(m_user->allowToChangePassword() ? tr("Password expired, please change") : tr("Your password has expired, Please contact the administrator to change it"));
         m_expiredStateLabel->show();
         m_expiredSpacerItem->changeSize(0, EXPIRED_SPACER_ITEM_HEIGHT);
         break;
     default:
         break;
+    }
+    if (m_passwordAuth) {
+        m_passwordAuth->setPasswordLineEditEnabled(m_model->appType() != Login || m_user->allowToChangePassword());
+    }
+    if (m_singleAuth) {
+        m_singleAuth->setPasswordLineEditEnabled(m_model->appType() != Login || m_user->allowToChangePassword());
     }
 }
 

--- a/src/session-widgets/mfa_widget.cpp
+++ b/src/session-widgets/mfa_widget.cpp
@@ -236,6 +236,8 @@ void MFAWidget::initPasswdAuth()
     m_passwordAuth->setCapsLockVisible(m_capslockMonitor->isCapslockOn());
     m_passwordAuth->setPasswordHint(m_user->passwordHint());
     m_passwordAuth->setAuthStatueVisible(true);
+    m_passwordAuth->setPasswordLineEditEnabled(m_model->currentUser()->allowToChangePassword() || m_model->appType() != Login);
+
     m_mainLayout->insertWidget(m_index, m_passwordAuth);
 
     connect(m_passwordAuth, &AuthPassword::activeAuth, this, [this] {

--- a/src/session-widgets/sfa_widget.cpp
+++ b/src/session-widgets/sfa_widget.cpp
@@ -129,6 +129,10 @@ void SFAWidget::setAuthType(const int type)
 {
     qDebug() << Q_FUNC_INFO << "SFAWidget::setAuthType:" << type;
     int authType = type;
+    if (!m_model->currentUser()->allowToChangePassword() && m_model->appType() == Login) {
+        qInfo() << "Password is expired";
+        authType = AT_Password;
+    }
     if (useCustomAuth()) {
         authType |= AT_Custom;
         initCustomAuth();
@@ -399,6 +403,7 @@ void SFAWidget::initSingleAuth()
     m_singleAuth->setCurrentUid(m_model->currentUser()->uid());
     replaceWidget(m_singleAuth);
     m_frameDataBind->updateValue("SFAType", AT_PAM);
+    m_singleAuth->setPasswordLineEditEnabled(m_model->currentUser()->allowToChangePassword() || m_model->appType() != Login);
 
     connect(m_singleAuth, &AuthSingle::activeAuth, this, &SFAWidget::onActiveAuth);
     connect(m_singleAuth, &AuthSingle::authFinished, this, [this](const int authState) {
@@ -471,6 +476,7 @@ void SFAWidget::initPasswdAuth()
     m_passwordAuth = new AuthPassword(this);
     m_passwordAuth->setCurrentUid(m_model->currentUser()->uid());
     m_passwordAuth->hide();
+    m_passwordAuth->setPasswordLineEditEnabled(m_model->currentUser()->allowToChangePassword() || m_model->appType() != Login);
 
     connect(m_passwordAuth, &AuthPassword::activeAuth, this, &SFAWidget::onActiveAuth);
     connect(m_passwordAuth, &AuthPassword::authFinished, this, [this](const int authState) {

--- a/src/session-widgets/userinfo.h
+++ b/src/session-widgets/userinfo.h
@@ -19,6 +19,11 @@ class User : public QObject
 {
     Q_OBJECT
 public:
+    enum AccountType {
+        NormalUser,
+        Administrator
+    };
+
     enum UserType {
         Native,
         ADDomain,
@@ -59,6 +64,7 @@ public:
 
     bool operator==(const User &user) const;
 
+    inline int accountType() const { return m_accountType; }
     inline bool isAutomaticLogin() const { return m_isAutomaticLogin; }
     inline bool isPasswordValid() const { return m_isPasswordValid; }
     inline bool isLogin() const { return m_isLogin; }
@@ -92,6 +98,7 @@ public:
     void updateLimitsInfo(const QString &info);
     void updateLoginState(const bool isLogin);
     void setLastAuthType(const int type);
+    bool allowToChangePassword() const;
 
     virtual void setKeyboardLayout(const QString &keyboard) { Q_UNUSED(keyboard) }
     virtual void updatePasswordExpiredInfo() { }
@@ -123,6 +130,7 @@ protected:
     QString userPwdName(const uid_t uid) const;
 
 protected:
+    int m_accountType;                   // 账户类型
     bool m_isAutomaticLogin;             // 自动登录
     bool m_isLogin;                      // 登录状态
     bool m_isNoPasswordLogin;            // 无密码登录
@@ -182,6 +190,7 @@ private slots:
     void updateWeekdayFormat(const int format);
     void updateUid(const QString &uid);
     void updateUse24HourFormat(const bool is24HourFormat);
+    void updateAccountType();
 
 private:
     void initConnections();


### PR DESCRIPTION
增加dconfig配置，默认打开，当关闭后，如果不是管理员用户，则不让在登录界面修改密码

Log: 密码过期后密码权限的修改
Task: https://pms.uniontech.com/story-view-23625.html
Influence: 密码修改权限
Change-Id: Id01ddd2f96024a7c47b275b20916d385390793a8