### PR TITLE
fix: 修复S3/S4通过指纹唤醒后，概率性出现指纹不响应问题

### DIFF
--- a/plugins/one-key-login/login_module.cpp
+++ b/plugins/one-key-login/login_module.cpp
@@ -83,7 +83,8 @@ LoginModule::LoginModule(QObject *parent)
 
     // 超时没接收到一键登录信号，视为失败
     m_waitAcceptSignalTimer = new QTimer(this);
-    m_waitAcceptSignalTimer->setInterval(800);
+    // 为配合华为指纹规避bug 182893，将时间改为1500毫秒，慎重修改
+    m_waitAcceptSignalTimer->setInterval(1500);
     connect(m_waitAcceptSignalTimer, &QTimer::timeout, this, [this] {
         qInfo() << Q_FUNC_INFO << "start 2.5s, m_isAcceptFingerprintSignal" << m_isAcceptFingerprintSignal;
         QDBusMessage m = QDBusMessage::createMethodCall("com.deepin.daemon.Authenticate", "/com/deepin/daemon/Authenticate/Fingerprint",


### PR DESCRIPTION
根据华为要求,进行规避处理,将800毫秒超时换成1500毫秒

Log: 华为指纹优化
Bug: https://pms.uniontech.com/bug-view-177695.html,https://pms.uniontech.com/bug-view-174585.html
Influence: S3指纹唤醒
Change-Id: I10272823e0fc36e26f38fade68230f5f7602fa11