### PR TITLE
fix: 修复KLV在登录界面会先黑一下的问题

### DIFF
--- a/src/app/lightdm-deepin-greeter.cpp
+++ b/src/app/lightdm-deepin-greeter.cpp
@@ -398,7 +398,11 @@ int main(int argc, char* argv[])
         QObject::connect(loginFrame, &LoginWindow::requestEndAuthentication, worker, &GreeterWorker::endAuthentication);
         QObject::connect(loginFrame, &LoginWindow::authFinished, worker, &GreeterWorker::onAuthFinished);
         QObject::connect(worker, &GreeterWorker::requestUpdateBackground, loginFrame, &LoginWindow::updateBackground);
-        loginFrame->setVisible(model->visible());
+        if (!IsWayland) {
+            loginFrame->setVisible(model->visible());
+        } else {
+            QObject::connect(worker, &GreeterWorker::showLoginWindow, loginFrame, &LoginWindow::setVisible);
+        }
         return loginFrame;
     };
 
@@ -413,7 +417,9 @@ int main(int argc, char* argv[])
     checker.setOutputFormat(DAccessibilityChecker::FullFormat);
     checker.start();
 #endif
-    model->setVisible(true);
+    if (!IsWayland) {
+        model->setVisible(true);
+    }
 
     return a.exec();
 }

--- a/src/lightdm-deepin-greeter/greeter_display_wayland.cpp
+++ b/src/lightdm-deepin-greeter/greeter_display_wayland.cpp
@@ -107,22 +107,24 @@ void GreeterDisplayWayland::setupRegistry(Registry *registry)
         if (!m_pManager) {
             m_pManager = registry->createOutputManagement(name, version, this);
             if (!m_pManager || !m_pManager->isValid()) {
-                qDebug() << "create manager is nullptr or not valid!";
+                qWarning() << "create manager is nullptr or not valid!";
                 return;
             }
             if (!m_pConf) {
                 m_pConf = m_pManager->createConfiguration();
                 if (!m_pConf || !m_pConf->isValid()) {
-                    qDebug() << "create output configure is null or is not vaild";
+                    qWarning() << "create output configure is null or is not vaild";
                     return;
                 }
                 disconnect(m_pConf, &OutputConfiguration::applied, this, nullptr);
                 disconnect(m_pConf, &OutputConfiguration::failed, this, nullptr);
                 connect(m_pConf, &OutputConfiguration::applied, [this] {
-                    qDebug() << "Configuration applied!";
+                    qInfo() << "Configuration applied!";
+                    Q_EMIT setOutputFinished();
                 });
                 connect(m_pConf, &OutputConfiguration::failed, [this] {
-                    qDebug() << "Configuration failed!";
+                    qWarning() << "Configuration failed!";
+                    Q_EMIT setOutputFinished();
                 });
             }
         }
@@ -134,7 +136,7 @@ void GreeterDisplayWayland::setupRegistry(Registry *registry)
         auto dev = registry->createOutputDevice(name, version);
         if (!dev || !dev->isValid())
         {
-            qDebug() << "get dev is null or not valid!";
+            qWarning() << "get dev is null or not valid!";
             return;
         }
 
@@ -202,7 +204,7 @@ void GreeterDisplayWayland::setOutputs()
         m_setOutputTimer->stop();
     }
     if (MonitorConfigsForUuid_v1.size() == 0) {
-        qDebug() << "has no monitors ...";
+        qWarning() << "has no monitors ...";
         return;
     }
     QString uuidKey;
@@ -302,7 +304,7 @@ void GreeterDisplayWayland::setOutputs()
                 }
             }
             if (id.isEmpty()) {
-                qDebug() << "invalid monitor ...";
+                qWarning() << "invalid monitor ...";
                 break;
             }
             MonitorConfigsForUuid_v1[id].x = jsonMonitorConfig.value("X").toInt();
@@ -375,7 +377,7 @@ QSize GreeterDisplayWayland::commonSizeForMirrorMode()
 
 void GreeterDisplayWayland::applyDefault()
 {
-    qDebug() << "applyDefault ...";
+    qInfo() << "applyDefault ...";
     QSize applySize;
     if (m_displayMode == Mirror_Mode) {
        applySize = commonSizeForMirrorMode();
@@ -395,11 +397,11 @@ void GreeterDisplayWayland::applyDefault()
                 break;
             }
         }
-        qDebug() << "set output setPosition to " << o.x() << o.y();
+        qInfo() << "set output setPosition to " << o.x() << o.y();
         m_pConf->setPosition(dev, o);
-        qDebug() << "set output setEnabled to " << enabled;
+        qInfo() << "set output setEnabled to " << enabled;
         m_pConf->setEnabled(dev, OutputDevice::Enablement(enabled));
-        qDebug() << "set output transform to 0";
+        qInfo() << "set output transform to 0";
         m_pConf->setTransform(dev, OutputDevice::Transform(0));
         m_pConf->apply();
         // 找不到配置文件，如果是扩展模式，默认横向扩展，如果是仅单屏默认点亮第一个屏幕
@@ -414,7 +416,7 @@ void GreeterDisplayWayland::applyDefault()
 
 void GreeterDisplayWayland::applyConfig(QString uuid)
 {
-    qDebug() << "applyConfig ...";
+    qInfo() << "applyConfig ...";
     auto monitor = MonitorConfigsForUuid_v1[uuid];
     auto dev = monitor.dev;
     bool modeSet = false;
@@ -430,11 +432,11 @@ void GreeterDisplayWayland::applyConfig(QString uuid)
     if (!modeSet) {
         m_pConf->setMode(dev, dev->modes()[0].id);
     }
-    qDebug() << "set output setPosition to " << monitor.x << monitor.y;
+    qInfo() << "set output setPosition to " << monitor.x << monitor.y;
     m_pConf->setPosition(dev, QPoint(monitor.x, monitor.y));
-    qDebug() << "set output setEnabled to " << monitor.enabled;
+    qInfo() << "set output setEnabled to " << monitor.enabled;
     m_pConf->setEnabled(dev, OutputDevice::Enablement(monitor.enabled));
-    qDebug() << "set output transform to " << monitor.transform;
+    qInfo() << "set output transform to " << monitor.transform;
     m_pConf->setTransform(dev, OutputDevice::Transform(monitor.transform));
     m_pConf->apply();
     MonitorConfigsForUuid_v1[uuid].hasCof = true;

--- a/src/lightdm-deepin-greeter/greeter_display_wayland.h
+++ b/src/lightdm-deepin-greeter/greeter_display_wayland.h
@@ -60,6 +60,9 @@ public:
 
     void start();
 
+signals:
+    void setOutputFinished();
+
 private:
     void setupRegistry(Registry *registry);
     void onDeviceChanged(OutputDevice *dev);

--- a/src/lightdm-deepin-greeter/greeterworker.cpp
+++ b/src/lightdm-deepin-greeter/greeterworker.cpp
@@ -55,6 +55,12 @@ GreeterWorker::GreeterWorker(SessionBaseModel *const model, QObject *parent)
 #ifdef USE_DEEPIN_WAYLAND
     if (!DGuiApplicationHelper::isXWindowPlatform()) {
         m_greeterDisplayWayland = new GreeterDisplayWayland();
+        connect(m_greeterDisplayWayland, &GreeterDisplayWayland::setOutputFinished, this, [this] {
+            QTimer::singleShot(100, this, [this] { // 延时等待显示数据设置完成
+                Q_EMIT showLoginWindow(true);
+                m_model->setVisible(true);
+            });
+        });
         m_greeterDisplayWayland->start();
     }
 #endif


### PR DESCRIPTION
原因：注销后，窗管会第一时间点亮屏幕，此时显示模式还未设置完成，所以会看到设置前的一帧画面
方案：设置完成后在显示登录界面

Log: 修复KLV在登录界面会先黑一下的问题
Bug: https://pms.uniontech.com/bug-view-182579.html
Influence: 登录界面分辨率
Change-Id: I98f419616305b32881175c7198161d41c262cf45