### PR TITLE
fix: display error of user type

### DIFF
--- a/src/widgets/useritemdelegate.cpp
+++ b/src/widgets/useritemdelegate.cpp
@@ -211,7 +211,7 @@ int UserItemDelegate::stringWidth(const QString &str, int fontSize, bool isBold)
     font.setPixelSize(fontSize);
 
     QFontMetrics fm(font);
-    return fm.horizontalAdvance(str);
+    return fm.boundingRect(str).width();
 }
 
 QString UserItemDelegate::elidedText(const QString &originString, int width, int fontSize, bool isBold) const


### PR DESCRIPTION
Using the exact width from stringWidth as paint rect of user type will lead to wrap of text like "Standard User". While height is fixed. Therefore, only "Standard" is displayed. Add one more pixel to paint rect to avoid wrap of such kind of text.

Log: fix display error of user type in user popup list