### PR TITLE
fix: black rectangular background of popup

### DIFF
--- a/src/session-widgets/lockcontent.cpp
+++ b/src/session-widgets/lockcontent.cpp
@@ -370,7 +370,8 @@ void LockContent::hideEvent(QHideEvent *event)
 {
     if (!m_shutdownFrame.isNull())
         m_shutdownFrame->recoveryLayout();
-
+    // explicitly hide popup in case fake window layer is shown next time
+    hidePopup();
     return SessionBaseWindow::hideEvent(event);
 }
 

--- a/src/session-widgets/sessionbasewindow.cpp
+++ b/src/session-widgets/sessionbasewindow.cpp
@@ -16,6 +16,7 @@ SessionBaseWindow::SessionBaseWindow(QWidget *parent)
     , m_TopFrame(new QFrame(this))
     , m_centerFrame(new QFrame(this))
     , m_bottomFrame(new QFrame(this))
+    , m_fakeWindowLayer(new FakeWindowLayer(this))
     , m_mainLayout(new QVBoxLayout(this))
     , m_topLayout(new QHBoxLayout(this))
     , m_centerLayout(new QVBoxLayout(this))
@@ -174,6 +175,8 @@ void SessionBaseWindow::initUI()
     m_bottomFrame->setStyleSheet("background-color: gray");
 #endif
     setLayout(m_mainLayout);
+    m_fakeWindowLayer->setFixedSize(size());
+    m_fakeWindowLayer->setAccessibleName("FakeWindowLayer");
 }
 
 QSize SessionBaseWindow::getCenterContentSize()
@@ -205,6 +208,7 @@ void SessionBaseWindow::resizeEvent(QResizeEvent *event)
     m_mainLayout->setContentsMargins(getMainLayoutMargins());
     m_TopFrame->setFixedHeight(autoScaledSize(LOCK_CONTENT_TOPBOTTOM_WIDGET_HEIGHT));
     m_bottomFrame->setFixedHeight(autoScaledSize(LOCK_CONTENT_TOPBOTTOM_WIDGET_HEIGHT));
+    m_fakeWindowLayer->setFixedSize(size());
 
     QFrame::resizeEvent(event);
 }
@@ -217,6 +221,29 @@ void SessionBaseWindow::setTopFrameVisible(bool visible)
 void SessionBaseWindow::setBottomFrameVisible(bool visible)
 {
     m_bottomFrame->setVisible(visible);
+}
+
+void SessionBaseWindow::showPopup(QPoint globalPos, QWidget *popup)
+{
+    m_fakeWindowLayer->setContent(popup);
+    QPoint localPos = m_fakeWindowLayer->mapFromGlobal(globalPos);
+    popup->move(localPos);
+    m_fakeWindowLayer->raise();
+    m_fakeWindowLayer->show();
+}
+
+void SessionBaseWindow::hidePopup()
+{
+    m_fakeWindowLayer->hide();
+}
+
+SessionBaseWindow *SessionBaseWindow::findFromChild(const QWidget *child)
+{
+    QWidget *pw = child->parentWidget();
+    while (pw && !qobject_cast<SessionBaseWindow *>(pw)) {
+        pw = pw->parentWidget();
+    }
+    return qobject_cast<SessionBaseWindow *>(pw);
 }
 
 /**

--- a/src/session-widgets/sessionbasewindow.h
+++ b/src/session-widgets/sessionbasewindow.h
@@ -4,6 +4,7 @@
 
 #ifndef SESSIONBASEWINDOW_H
 #define SESSIONBASEWINDOW_H
+#include "fakewindowlayer.h"
 
 #include <QFrame>
 #include <QVBoxLayout>
@@ -29,6 +30,11 @@ public:
     void changeCenterSpaceSize(int w, int h);
     void setTopFrameVisible(bool visible);
     void setBottomFrameVisible(bool visible);
+    void showPopup(QPoint globalPos, QWidget *popup);
+    inline void showPopup(int globalX, int globalY, QWidget *popup) { showPopup(QPoint(globalX, globalY), popup); }
+    void hidePopup();
+
+    static SessionBaseWindow *findFromChild(const QWidget *child);
 
 private:
     void initUI();
@@ -42,6 +48,10 @@ private:
     QFrame *m_TopFrame;                 // 上布局容器(按照比例计算，其高度固定为当前屏幕高度的132/1080)
     QFrame *m_centerFrame;              // 中间布局容器(高度 = 屏幕高度 - 上下两个容器的高度)
     QFrame *m_bottomFrame;              // 下布局容器(按照比例计算，其高度固定为当前屏幕高度的132/1080)
+
+    // An overlay layer used to emulate window like popups.
+    // When this layer is visible, it will catch all events for its parent SessionBaseWindow.
+    FakeWindowLayer *m_fakeWindowLayer;
 
     QVBoxLayout *m_mainLayout;          // 主布局(垂直布局，将整个屏幕分为上、中、下三部分,其上下的margin为当前高度的33/1080)
     QHBoxLayout *m_topLayout;           // 上布局(水平布局)

--- a/src/widgets/controlwidget.h
+++ b/src/widgets/controlwidget.h
@@ -127,6 +127,7 @@ private:
     void updateTapOrder();
     int focusedBtnIndex();
     void showPopupWidget(const FlotingButton *clickedBtn);
+    void hidePopupWidget();
 
 private slots:
     void showInfoTips();

--- a/src/widgets/fakewindowlayer.cpp
+++ b/src/widgets/fakewindowlayer.cpp
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "fakewindowlayer.h"
+#include <QEvent>
+#include <QDebug>
+#include <QMouseEvent>
+#include <QApplication>
+
+FakeWindowLayer::FakeWindowLayer(QWidget *parent)
+    : QWidget(parent)
+    , m_content(nullptr)
+    , m_savedParent(nullptr)
+    , m_savedFocus(nullptr)
+{
+    setAutoFillBackground(false);
+    setAttribute(Qt::WA_WState_Hidden); // ensure invisible to parent
+}
+
+void FakeWindowLayer::setContent(QWidget *toSet)
+{
+    if (content() && content() != toSet) {
+        content()->setParent(m_savedParent);
+        content()->hide();
+    }
+    if (!toSet) {
+        m_content = nullptr;
+        return;
+    }
+    m_savedFocus = QApplication::focusWidget();
+    if (toSet->parentWidget() != this) {
+        // In case that setContent is invoked many times
+        m_savedParent = toSet->parentWidget();
+        toSet->setParent(this);
+    }
+    m_content = toSet;
+    m_content->show();
+}
+
+QWidget *FakeWindowLayer::content() const
+{
+    return m_content;
+}
+
+void FakeWindowLayer::mouseReleaseEvent(QMouseEvent *event)
+{
+    hide();
+    QWidget::mouseReleaseEvent(event);
+}
+
+void FakeWindowLayer::keyReleaseEvent(QKeyEvent *event)
+{
+    switch (event->key())
+    {
+    case Qt::Key_Escape:
+        hide();
+        break;
+    default:
+        break;
+    }
+    QWidget::keyReleaseEvent(event);
+}
+
+void FakeWindowLayer::hideEvent(QHideEvent *event)
+{
+    setContent(nullptr);
+    if (m_savedFocus) {
+        m_savedFocus->setFocus();
+    }
+    QWidget::hideEvent(event);
+}
+
+void FakeWindowLayer::setVisible(bool visible)
+{
+    if (content())
+        QWidget::setVisible(visible);
+    else
+        QWidget::setVisible(false);
+}

--- a/src/widgets/fakewindowlayer.h
+++ b/src/widgets/fakewindowlayer.h
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef FAKEWINDOWLAYER_H
+#define FAKEWINDOWLAYER_H
+
+#include <QWidget>
+
+class FakeWindowLayer : public QWidget
+{
+    Q_OBJECT
+    Q_PROPERTY(QWidget* content READ content WRITE setContent)
+public:
+    FakeWindowLayer(QWidget *parent = nullptr);
+    ~FakeWindowLayer() override = default;
+
+    void setContent(QWidget *toSet);
+    QWidget *content() const;
+    void setVisible(bool visible) override;
+
+protected:
+    void mouseReleaseEvent(QMouseEvent *event) override;
+    void keyReleaseEvent(QKeyEvent *event) override;
+    void hideEvent(QHideEvent *event) override;
+
+private:
+    QWidget *m_content;
+    QWidget *m_savedParent;
+    QWidget *m_savedFocus;
+};
+
+#endif  // FAKEWINDOWLAYER_H

--- a/src/widgets/roundpopupwidget.cpp
+++ b/src/widgets/roundpopupwidget.cpp
@@ -21,10 +21,8 @@ RoundPopupWidget::RoundPopupWidget(QWidget *parent)
 
 void RoundPopupWidget::initUI()
 {
-    setWindowFlags(Qt::FramelessWindowHint | Qt::Popup);
-    setAttribute(Qt::WA_TranslucentBackground);
-
     setBlurEnabled(true);
+    setBlendMode(DBlurEffectWidget::InWidgetBlend);
     setBlurRectXRadius(RADIUS);
     setBlurRectYRadius(RADIUS);
     setMaskColor(QColor(238, 238, 238, 0.8 * 255));

--- a/src/widgets/roundpopupwidget.cpp
+++ b/src/widgets/roundpopupwidget.cpp
@@ -8,10 +8,11 @@
 #include <QDebug>
 #include <QVBoxLayout>
 
-const int MARGIN = 5;
+static constexpr int MARGIN = 5;
+static constexpr int RADIUS = 18;
 
 RoundPopupWidget::RoundPopupWidget(QWidget *parent)
-    : QWidget(parent)
+    : DBlurEffectWidget(parent)
     , m_pContentWidget(nullptr)
     , m_mainLayout(new QVBoxLayout())
 {
@@ -23,6 +24,10 @@ void RoundPopupWidget::initUI()
     setWindowFlags(Qt::FramelessWindowHint | Qt::Popup);
     setAttribute(Qt::WA_TranslucentBackground);
 
+    setBlurEnabled(true);
+    setBlurRectXRadius(RADIUS);
+    setBlurRectYRadius(RADIUS);
+    setMaskColor(QColor(238, 238, 238, 0.8 * 255));
     m_mainLayout->setMargin(0);
     m_mainLayout->setContentsMargins(MARGIN, MARGIN, MARGIN, MARGIN);
     setLayout(m_mainLayout);
@@ -59,19 +64,4 @@ void RoundPopupWidget::hideEvent(QHideEvent *event)
         m_pContentWidget->hide();
 
     QWidget::hideEvent(event);
-}
-
-void RoundPopupWidget::paintEvent(QPaintEvent *event)
-{
-    const int radius = 18;
-
-    QPainter painter(this);
-    painter.setRenderHint(QPainter::Antialiasing);
-    painter.setPen(Qt::transparent);
-    painter.setBrush(QColor(238, 238, 238, int(0.8 * 255)));
-
-    QRect rect = this->rect();
-    rect.setWidth(rect.width() - 1);
-    rect.setHeight(rect.height() - 1);
-    painter.drawRoundedRect(rect, radius, radius);
 }

--- a/src/widgets/roundpopupwidget.h
+++ b/src/widgets/roundpopupwidget.h
@@ -5,15 +5,16 @@
 #ifndef ROUND_POPUP_WIDGET_H
 #define ROUND_POPUP_WIDGET_H
 
-#include <QWidget>
+#include <DBlurEffectWidget>
 
 class QVBoxLayout;
 
+using DTK_WIDGET_NAMESPACE::DBlurEffectWidget;
 /*!
  * \brief The RoundPopupWidget class
  * 圆角弹窗页面
  */
-class RoundPopupWidget : public QWidget
+class RoundPopupWidget : public DBlurEffectWidget
 {
     Q_OBJECT
 public:
@@ -25,7 +26,6 @@ public:
 
 protected:
     void hideEvent(QHideEvent *event) Q_DECL_OVERRIDE;
-    void paintEvent(QPaintEvent *event) Q_DECL_OVERRIDE;
 
 private:
     void initUI();


### PR DESCRIPTION
There is black rectangular background under round popup without a window manager when login. Change popup window to a plain widget, draw round rect ourselves.

Log: fix black rectangular background of popup