### PR TITLE
fix: second click of network won't close network panel

### DIFF
--- a/src/app/dde-lock.cpp
+++ b/src/app/dde-lock.cpp
@@ -79,9 +79,6 @@ int main(int argc, char *argv[])
     /* load translation files */
     loadTranslation(QLocale::system().name());
 
-    dss::module::ModulesLoader *modulesLoader = &dss::module::ModulesLoader::instance();
-    modulesLoader->start(QThread::LowestPriority);
-
     QCommandLineParser cmdParser;
     cmdParser.addHelpOption();
     cmdParser.addVersionOption();
@@ -97,8 +94,20 @@ int main(int argc, char *argv[])
     QCommandLineOption lockscreen(QStringList() << "l" << "lockscreen", "show lock screen");
     cmdParser.addOption(lockscreen);
 
-    QStringList xddd = app->arguments();
+    QCommandLineOption modulePath("p", "Paths to load modules from, separated by semicolon. This option will override default module loading paths including local and global.", "paths", QString());
+    cmdParser.addOption(modulePath);
+
     cmdParser.process(*app);
+
+    dss::module::ModulesLoader *modulesLoader = &dss::module::ModulesLoader::instance();
+
+    if (cmdParser.isSet(modulePath)) {
+        QString modulePathValue = cmdParser.value(modulePath);
+        QStringList paths = modulePathValue.split(":");
+        modulesLoader->setModulePaths(paths);
+    }
+
+    modulesLoader->start(QThread::LowestPriority);
 
     bool runDaemon = cmdParser.isSet(backend);
     bool showUserList = cmdParser.isSet(switchUser);

--- a/src/app/dde-lock.cpp
+++ b/src/app/dde-lock.cpp
@@ -43,6 +43,9 @@ int main(int argc, char *argv[])
     app->setApplicationName("org.deepin.dde.lock");
     app->setApplicationVersion("2015.1.0");
 
+    DLogManager::registerConsoleAppender();
+    DLogManager::registerFileAppender();
+
     //注册全局事件过滤器
     AppEventFilter appEventFilter;
     app->installEventFilter(&appEventFilter);
@@ -72,9 +75,6 @@ int main(int argc, char *argv[])
         palette.setColor(QPalette::Highlight, color);
         DGuiApplicationHelper::instance()->setApplicationPalette(palette);
     });
-
-    DLogManager::registerConsoleAppender();
-    DLogManager::registerFileAppender();
 
     /* load translation files */
     loadTranslation(QLocale::system().name());

--- a/src/app/lightdm-deepin-greeter.cpp
+++ b/src/app/lightdm-deepin-greeter.cpp
@@ -210,6 +210,8 @@ int main(int argc, char* argv[])
     qApp->setApplicationVersion("2015.1.0");
     qApp->setAttribute(Qt::AA_ForceRasterWidgets);
 
+    DLogManager::registerConsoleAppender();
+
     set_pointer();
 
     //注册全局事件过滤器
@@ -233,8 +235,6 @@ int main(int argc, char* argv[])
     DGuiApplicationHelper::generatePaletteColor(pa, DPalette::Dark, DGuiApplicationHelper::LightType);
     DGuiApplicationHelper::generatePaletteColor(pa, DPalette::ButtonText, DGuiApplicationHelper::LightType);
     DGuiApplicationHelper::instance()->setApplicationPalette(pa);
-
-    DLogManager::registerConsoleAppender();
 
     dss::module::ModulesLoader *modulesLoader = &dss::module::ModulesLoader::instance();
 

--- a/src/app/lightdm-deepin-greeter.cpp
+++ b/src/app/lightdm-deepin-greeter.cpp
@@ -237,6 +237,22 @@ int main(int argc, char* argv[])
     DLogManager::registerConsoleAppender();
 
     dss::module::ModulesLoader *modulesLoader = &dss::module::ModulesLoader::instance();
+
+    QCommandLineParser cmdParser;
+    cmdParser.addHelpOption();
+    cmdParser.addVersionOption();
+
+    QCommandLineOption modulePath("p", "Paths to load modules in debug mode, separated by semicolon.", "paths", QString());
+    cmdParser.addOption(modulePath);
+
+    cmdParser.process(a);
+
+    if (cmdParser.isSet(modulePath)) {
+        QString modulePathValue = cmdParser.value(modulePath);
+        QStringList paths = modulePathValue.split(":");
+        modulesLoader->setModulePaths(paths);
+    }
+
     modulesLoader->start(QThread::LowestPriority);
 
     const QString serviceName = "org.deepin.dde.Accounts1";

--- a/src/global_util/constants.h
+++ b/src/global_util/constants.h
@@ -55,5 +55,10 @@ enum AuthFactorType {
 };
 }
 
+namespace Popup
+{
+static constexpr int HorizontalMargin = 10;
+static constexpr int VerticalMargin = 10;
+}
 
 #endif // CONSTANTS_H

--- a/src/global_util/modules_loader.cpp
+++ b/src/global_util/modules_loader.cpp
@@ -19,6 +19,9 @@ const QString ModulesDir = "/usr/lib/dde-session-shell/modules";
 ModulesLoader::ModulesLoader(QObject *parent)
     : QThread(parent)
 {
+    QString localDir = QCoreApplication::applicationDirPath() + "/modules";
+    addModulePath(localDir);
+    addModulePath(ModulesDir);
 }
 
 ModulesLoader::~ModulesLoader()
@@ -49,11 +52,9 @@ QHash<QString, BaseModuleInterface *> ModulesLoader::findModulesByType(const int
 
 void ModulesLoader::run()
 {
-    findModule(ModulesDir);
-
-    // 本地编译modules
-    QString localDir = QCoreApplication::applicationDirPath() + "/modules";
-    findModule(localDir);
+    for (const auto &path : m_modulePaths) {
+        findModule(path);
+    }
 }
 
 bool ModulesLoader::checkVersion(const QString &target, const QString &base)

--- a/src/global_util/modules_loader.cpp
+++ b/src/global_util/modules_loader.cpp
@@ -107,7 +107,7 @@ void ModulesLoader::findModule(const QString &path)
         if (moduleVersion == "1.0.1" && !moduleInstance->isNeedInitPlugin()) {
             qInfo() << "plugin :" << moduleInstance->key() << " version:"
                     << moduleVersion << " is valid, but not need load";
-            return;
+            continue;
         }
 
         if (m_modules.contains(moduleInstance->key())) {

--- a/src/global_util/modules_loader.h
+++ b/src/global_util/modules_loader.h
@@ -21,6 +21,8 @@ public:
     inline QHash<QString, BaseModuleInterface *> moduleList() { return m_modules; }
     BaseModuleInterface *findModuleByName(const QString &name) const;
     QHash<QString, BaseModuleInterface *> findModulesByType(const int type) const;
+    inline void setModulePaths(const QStringList &paths) { m_modulePaths.clear(); m_modulePaths.append(paths); }
+    inline void addModulePath(const QString &path) { m_modulePaths.append(path); }
 
 signals:
     void moduleFound(BaseModuleInterface *);
@@ -39,6 +41,7 @@ private:
 
 private:
     QHash<QString, BaseModuleInterface *> m_modules;
+    QStringList m_modulePaths;
 };
 
 } // namespace module

--- a/src/session-widgets/lockcontent.cpp
+++ b/src/session-widgets/lockcontent.cpp
@@ -107,7 +107,8 @@ void LockContent::initConnections()
     connect(m_controlWidget, &ControlWidget::requestShutdown, this, [ = ] {
         m_model->setCurrentModeState(SessionBaseModel::ModeStatus::PowerMode);
     });
-    connect(m_controlWidget, &ControlWidget::requestShowModule, this, &LockContent::showModule);
+    connect(m_controlWidget, &ControlWidget::requestTogglePopup, this, &SessionBaseWindow::togglePopup);
+    connect(m_controlWidget, &ControlWidget::requestHidePopup, this, &SessionBaseWindow::hidePopup);
 
     //刷新背景单独与onStatusChanged信号连接，避免在showEvent事件时调用onStatusChanged而重复刷新背景，减少刷新次数
     connect(m_model, &SessionBaseModel::onStatusChanged, this, &LockContent::onStatusChanged);
@@ -427,7 +428,7 @@ void LockContent::updateTimeFormat(bool use24)
     }
 }
 
-void LockContent::showModule(const QString &name)
+void LockContent::toggleModule(const QString &name)
 {
     BaseModuleInterface *module = ModulesLoader::instance().findModuleByName(name);
     if (!module) {
@@ -436,11 +437,11 @@ void LockContent::showModule(const QString &name)
 
     switch (module->type()) {
     case BaseModuleInterface::LoginType:
+        setCenterContent(module->content());
         m_model->setCurrentModeState(SessionBaseModel::ModeStatus::PasswordMode);
         break;
     case BaseModuleInterface::TrayType:
-        setCenterContent(module->content());
-        break;
+        return;
     }
 }
 

--- a/src/session-widgets/lockcontent.h
+++ b/src/session-widgets/lockcontent.h
@@ -72,7 +72,7 @@ protected:
 
 protected:
     void updateTimeFormat(bool use24);
-    void showModule(const QString &name);
+    void toggleModule(const QString &name);
     void onUserListChanged(QList<std::shared_ptr<User>> list);
     void tryGrabKeyboard();
     void hideToplevelWindow();

--- a/src/session-widgets/sessionbasewindow.cpp
+++ b/src/session-widgets/sessionbasewindow.cpp
@@ -237,13 +237,12 @@ void SessionBaseWindow::hidePopup()
     m_fakeWindowLayer->hide();
 }
 
-SessionBaseWindow *SessionBaseWindow::findFromChild(const QWidget *child)
+void SessionBaseWindow::togglePopup(QPoint globalPos, QWidget *popup)
 {
-    QWidget *pw = child->parentWidget();
-    while (pw && !qobject_cast<SessionBaseWindow *>(pw)) {
-        pw = pw->parentWidget();
-    }
-    return qobject_cast<SessionBaseWindow *>(pw);
+    if (m_fakeWindowLayer->isVisible())
+        hidePopup();
+    else
+        showPopup(globalPos, popup);
 }
 
 /**

--- a/src/session-widgets/sessionbasewindow.h
+++ b/src/session-widgets/sessionbasewindow.h
@@ -33,8 +33,7 @@ public:
     void showPopup(QPoint globalPos, QWidget *popup);
     inline void showPopup(int globalX, int globalY, QWidget *popup) { showPopup(QPoint(globalX, globalY), popup); }
     void hidePopup();
-
-    static SessionBaseWindow *findFromChild(const QWidget *child);
+    void togglePopup(QPoint globalPos, QWidget *popup);
 
 private:
     void initUI();

--- a/src/widgets/controlwidget.cpp
+++ b/src/widgets/controlwidget.cpp
@@ -33,7 +33,7 @@
 using namespace dss;
 DCORE_USE_NAMESPACE
 
-bool FlotingButton::eventFilter(QObject *watch, QEvent *event)
+bool FloatingButton::eventFilter(QObject *watch, QEvent *event)
 {
     if (watch == this) {
         if (event->type() == QEvent::MouseButtonRelease) {
@@ -54,9 +54,9 @@ bool FlotingButton::eventFilter(QObject *watch, QEvent *event)
 ControlWidget::ControlWidget(const SessionBaseModel *model, QWidget *parent)
     : QWidget(parent)
     , m_mainLayout(nullptr)
-    , m_switchUserBtn(new FlotingButton(this))
-    , m_powerBtn(new FlotingButton(this))
-    , m_sessionBtn(new FlotingButton(this))
+    , m_switchUserBtn(new FloatingButton(this))
+    , m_powerBtn(new FloatingButton(this))
+    , m_sessionBtn(new FloatingButton(this))
     , m_keyboardBtn(nullptr)
     , m_contextMenu(new QMenu(this))
     , m_tipContentWidget(nullptr)
@@ -126,7 +126,7 @@ void ControlWidget::initUI()
     m_sessionBtn->hide();
     m_sessionBtn->setTipText(tr("Desktop Environment and Display Protocol"));
 
-    m_keyboardBtn = new FlotingButton(this);
+    m_keyboardBtn = new FloatingButton(this);
     m_keyboardBtn->setAccessibleName("KeyboardLayoutBtn");
     m_keyboardBtn->setFixedSize(BUTTON_SIZE);
     m_keyboardBtn->setAutoExclusive(true);
@@ -180,21 +180,21 @@ void ControlWidget::initConnect()
 {
     connect(&module::ModulesLoader::instance(), &module::ModulesLoader::moduleFound, this, &ControlWidget::addModule);
 
-    connect(m_sessionBtn, &FlotingButton::clicked, this, &ControlWidget::showSessionPopup);
-    connect(m_sessionBtn, &FlotingButton::requestShowTips, this, &ControlWidget::showInfoTips);
-    connect(m_sessionBtn, &FlotingButton::requestHideTips, this, &ControlWidget::hideInfoTips);
+    connect(m_sessionBtn, &FloatingButton::clicked, this, &ControlWidget::showSessionPopup);
+    connect(m_sessionBtn, &FloatingButton::requestShowTips, this, &ControlWidget::showInfoTips);
+    connect(m_sessionBtn, &FloatingButton::requestHideTips, this, &ControlWidget::hideInfoTips);
 
-    connect(m_switchUserBtn, &FlotingButton::clicked, this, &ControlWidget::showUserListPopupWidget);
-    connect(m_switchUserBtn, &FlotingButton::requestShowTips, this, &ControlWidget::showInfoTips);
-    connect(m_switchUserBtn, &FlotingButton::requestHideTips, this, &ControlWidget::hideInfoTips);
+    connect(m_switchUserBtn, &FloatingButton::clicked, this, &ControlWidget::showUserListPopupWidget);
+    connect(m_switchUserBtn, &FloatingButton::requestShowTips, this, &ControlWidget::showInfoTips);
+    connect(m_switchUserBtn, &FloatingButton::requestHideTips, this, &ControlWidget::hideInfoTips);
 
-    connect(m_powerBtn, &FlotingButton::clicked, this, &ControlWidget::requestShutdown);
-    connect(m_powerBtn, &FlotingButton::requestShowTips, this, &ControlWidget::showInfoTips);
-    connect(m_powerBtn, &FlotingButton::requestHideTips, this, &ControlWidget::hideInfoTips);
+    connect(m_powerBtn, &FloatingButton::clicked, this, &ControlWidget::requestShutdown);
+    connect(m_powerBtn, &FloatingButton::requestShowTips, this, &ControlWidget::showInfoTips);
+    connect(m_powerBtn, &FloatingButton::requestHideTips, this, &ControlWidget::hideInfoTips);
 
-    connect(m_keyboardBtn, &FlotingButton::clicked, this, &ControlWidget::setKBLayoutVisible);
-    connect(m_keyboardBtn, &FlotingButton::requestShowTips, this, &ControlWidget::showInfoTips);
-    connect(m_keyboardBtn, &FlotingButton::requestHideTips, this, &ControlWidget::hideInfoTips);
+    connect(m_keyboardBtn, &FloatingButton::clicked, this, &ControlWidget::setKBLayoutVisible);
+    connect(m_keyboardBtn, &FloatingButton::requestShowTips, this, &ControlWidget::showInfoTips);
+    connect(m_keyboardBtn, &FloatingButton::requestHideTips, this, &ControlWidget::hideInfoTips);
 
     connect(m_model, &SessionBaseModel::currentUserChanged, this, &ControlWidget::setUser);
 }
@@ -210,27 +210,24 @@ void ControlWidget::addModule(module::BaseModuleInterface *module)
 
     trayModule->init();
 
-    FlotingButton *button = new FlotingButton(this);
+    FloatingButton *button = new FloatingButton(this);
     button->setIconSize(QSize(26, 26));
     button->setFixedSize(QSize(52, 52));
     button->setAutoExclusive(true);
     button->setBackgroundRole(DPalette::Button);
 
     if (QWidget *trayWidget = trayModule->itemWidget()) {
-        trayWidget->setParent(this);
-        QHBoxLayout *layout = new QHBoxLayout(this);
+        QHBoxLayout *layout = new QHBoxLayout(button);
         layout->setSpacing(0);
         layout->setMargin(0);
         layout->addWidget(trayWidget);
-
-        button->setLayout(layout);
     } else {
         button->setIcon(QIcon(trayModule->icon()));
     }
 
     m_modules.insert(trayModule->key(), button);
 
-    connect(button, &FlotingButton::requestShowMenu, this, [ = ] {
+    connect(button, &FloatingButton::requestShowMenu, this, [ = ] {
         const QString menuJson = trayModule->itemContextMenu();
         if (menuJson.isEmpty())
             return;
@@ -258,7 +255,7 @@ void ControlWidget::addModule(module::BaseModuleInterface *module)
             trayModule->invokedMenuItem(action->data().toString(), true);
     });
 
-    connect(button, &FlotingButton::requestShowTips, this, [ = ] {
+    connect(button, &FloatingButton::requestShowTips, this, [ = ] {
         if (trayModule->itemTipsWidget()) {
             m_tipsWidget->setContent(trayModule->itemTipsWidget());
             QPoint p = m_tipsWidget->parentWidget() ? m_tipsWidget->parentWidget()->mapFromGlobal(mapToGlobal(button->pos())) : mapToGlobal(button->pos());
@@ -266,7 +263,7 @@ void ControlWidget::addModule(module::BaseModuleInterface *module)
         }
     });
 
-    connect(button, &FlotingButton::requestHideTips, this, [ = ] {
+    connect(button, &FloatingButton::requestHideTips, this, [ = ] {
         if (m_tipsWidget->getContent())
             m_tipsWidget->getContent()->setVisible(false);
         m_tipsWidget->hide();
@@ -352,7 +349,7 @@ void ControlWidget::chooseToSession(const QString &session)
 
 void ControlWidget::setKBLayoutVisible()
 {
-    FlotingButton *clickedButton = static_cast<FlotingButton *>(sender());
+    FloatingButton *clickedButton = static_cast<FloatingButton *>(sender());
     if (!clickedButton)
         return;
 
@@ -464,7 +461,7 @@ void ControlWidget::updateTapOrder()
     // 找出所有显示的按钮
     m_showedBtnList.clear();
     for(int i = 0; i < m_mainLayout->count(); ++i) {
-        FlotingButton *btn = qobject_cast<FlotingButton *>(m_mainLayout->itemAt(i)->widget());
+        FloatingButton *btn = qobject_cast<FloatingButton *>(m_mainLayout->itemAt(i)->widget());
         if (btn && btn->isVisible()) {
             m_showedBtnList.append(btn);
         }
@@ -481,7 +478,7 @@ void ControlWidget::updateTapOrder()
 int ControlWidget::focusedBtnIndex()
 {
     for (int index = 0; index < m_showedBtnList.count(); index++) {
-        FlotingButton *btn = m_showedBtnList.at(index);
+        FloatingButton *btn = m_showedBtnList.at(index);
         if (btn && btn->hasFocus()) {
             return index;
         }
@@ -492,7 +489,7 @@ int ControlWidget::focusedBtnIndex()
 
 void ControlWidget::showInfoTips()
 {
-    FlotingButton * button = qobject_cast<FlotingButton *>(sender());
+    FloatingButton * button = qobject_cast<FloatingButton *>(sender());
     if (!button) {
         return;
     }
@@ -523,7 +520,7 @@ void ControlWidget::showEvent(QShowEvent *event)
     QWidget::showEvent(event);
 }
 
-void ControlWidget::showPopupWidget(const FlotingButton *clickedBtn)
+void ControlWidget::showPopupWidget(const FloatingButton *clickedBtn)
 {
     if (!m_roundPopupWidget || !clickedBtn || !topLevelWidget())
         return;

--- a/src/widgets/controlwidget.h
+++ b/src/widgets/controlwidget.h
@@ -102,7 +102,8 @@ signals:
     void requestSwitchUser(std::shared_ptr<User> user);
     void requestShutdown();
     void requestSwitchSession(const QString &session);
-    void requestShowModule(const QString &name);
+    void requestTogglePopup(QPoint globalPos, QWidget *popup);
+    void requestHidePopup();
 
 public slots:
     void addModule(dss::module::BaseModuleInterface *module);
@@ -126,8 +127,7 @@ private:
     void updateLayout();
     void updateTapOrder();
     int focusedBtnIndex();
-    void showPopupWidget(const FloatingButton *clickedBtn);
-    void hidePopupWidget();
+    void toggleButtonPopup(const FloatingButton *button, QWidget *popup);
 
 private slots:
     void showInfoTips();

--- a/src/widgets/controlwidget.h
+++ b/src/widgets/controlwidget.h
@@ -44,27 +44,27 @@ class RoundPopupWidget;
 const int BlurRadius = 15;
 const int BlurTransparency = 70;
 
-class FlotingButton : public DFloatingButton
+class FloatingButton : public DFloatingButton
 {
     Q_OBJECT
 public:
-    explicit FlotingButton(QWidget *parent = nullptr)
+    explicit FloatingButton(QWidget *parent = nullptr)
         : DFloatingButton(parent) {
         installEventFilter(this);
     }
-    explicit FlotingButton(QStyle::StandardPixmap iconType = static_cast<QStyle::StandardPixmap>(-1), QWidget *parent = nullptr)
+    explicit FloatingButton(QStyle::StandardPixmap iconType = static_cast<QStyle::StandardPixmap>(-1), QWidget *parent = nullptr)
         : DFloatingButton(iconType, parent) {
         installEventFilter(this);
     }
-    explicit FlotingButton(DStyle::StandardPixmap iconType = static_cast<DStyle::StandardPixmap>(-1), QWidget *parent = nullptr)
+    explicit FloatingButton(DStyle::StandardPixmap iconType = static_cast<DStyle::StandardPixmap>(-1), QWidget *parent = nullptr)
         : DFloatingButton(iconType, parent) {
         installEventFilter(this);
     }
-    explicit FlotingButton(const QString &text, QWidget *parent = nullptr)
+    explicit FloatingButton(const QString &text, QWidget *parent = nullptr)
         : DFloatingButton(text, parent) {
         installEventFilter(this);
     }
-    FlotingButton(const QIcon& icon, const QString &text = QString(), QWidget *parent = nullptr)
+    FloatingButton(const QIcon& icon, const QString &text = QString(), QWidget *parent = nullptr)
         : DFloatingButton(icon, text, parent) {
         installEventFilter(this);
     }
@@ -126,7 +126,7 @@ private:
     void updateLayout();
     void updateTapOrder();
     int focusedBtnIndex();
-    void showPopupWidget(const FlotingButton *clickedBtn);
+    void showPopupWidget(const FloatingButton *clickedBtn);
     void hidePopupWidget();
 
 private slots:
@@ -134,13 +134,13 @@ private slots:
     void hideInfoTips();
 
 private:
-    QList<FlotingButton *> m_showedBtnList;
+    QList<FloatingButton *> m_showedBtnList;
 
     QHBoxLayout *m_mainLayout;
-    FlotingButton *m_switchUserBtn;
-    FlotingButton *m_powerBtn;
-    FlotingButton *m_sessionBtn;
-    FlotingButton *m_keyboardBtn;         // 键盘布局按钮
+    FloatingButton *m_switchUserBtn;
+    FloatingButton *m_powerBtn;
+    FloatingButton *m_sessionBtn;
+    FloatingButton *m_keyboardBtn;         // 键盘布局按钮
 
     std::shared_ptr<User> m_curUser;
     const SessionBaseModel *m_model;

--- a/src/widgets/fakewindowlayer.cpp
+++ b/src/widgets/fakewindowlayer.cpp
@@ -36,6 +36,7 @@ void FakeWindowLayer::setContent(QWidget *toSet)
     }
     m_content = toSet;
     m_content->show();
+    m_content->setFocus();
 }
 
 QWidget *FakeWindowLayer::content() const

--- a/src/widgets/roundpopupwidget.cpp
+++ b/src/widgets/roundpopupwidget.cpp
@@ -7,6 +7,9 @@
 #include <QPainter>
 #include <QDebug>
 #include <QVBoxLayout>
+#include <QEvent>
+#include <QResizeEvent>
+#include "constants.h"
 
 static constexpr int MARGIN = 5;
 static constexpr int RADIUS = 18;
@@ -42,11 +45,12 @@ void RoundPopupWidget::setContent(QWidget *widget)
     if (!widget)
         return;
 
-    setFixedSize(widget->size() + QSize(MARGIN * 2, MARGIN * 2));
+    resize(widget->size() + QSize(MARGIN * 2, MARGIN * 2));
     if (widget->parentWidget() != this)
         m_savedParent = widget->parentWidget();
     m_mainLayout->addWidget(widget);
     m_pContentWidget = widget;
+    m_pContentWidget->installEventFilter(this);
     widget->show();
 }
 
@@ -59,4 +63,39 @@ void RoundPopupWidget::hideEvent(QHideEvent *event)
 {
     setContent(nullptr);
     QWidget::hideEvent(event);
+}
+
+bool RoundPopupWidget::eventFilter(QObject *watched, QEvent *event)
+{
+    switch(event->type()) {
+    case QEvent::Resize: {
+        if (watched != m_pContentWidget)
+            break;
+        QResizeEvent *resizeEvent = static_cast<QResizeEvent *>(event);
+        QSize newSize = resizeEvent->size() + QSize(MARGIN * 2, MARGIN * 2);
+        // Recalculate the geometry
+        QRect oldGeometry = geometry();
+        QPoint anchor = parentWidget()->mapToGlobal({oldGeometry.left() + oldGeometry.width() / 2 - 1, oldGeometry.bottom()});
+        // Bound to screen and margin. If we can't show the popup fully, assume it's a scroll area, we just set a max height.
+        QRect boundary = topLevelWidget()->frameGeometry();
+        boundary.adjust((boundary.width() + DDESESSIONCC::PASSWDLINEEIDT_WIDTH) / 2 + Popup::HorizontalMargin, Popup::VerticalMargin, -Popup::HorizontalMargin, 0);
+        boundary.setBottom(anchor.y());
+        QSize properSize = newSize.boundedTo(boundary.size());
+        QPoint newTopLeft(anchor.x() - properSize.width() / 2 + 1, anchor.y() - properSize.height() + 1);
+        QRect newGeometry(newTopLeft, properSize);
+        if (!boundary.contains(newGeometry)) {
+            if (boundary.contains(newGeometry.bottomLeft())) {
+                newGeometry.moveBottomRight(boundary.bottomRight());
+            } else {
+                newGeometry.moveBottomLeft(boundary.bottomLeft());
+            }
+        }
+        newGeometry.moveTopLeft(parentWidget()->mapFromGlobal(newGeometry.topLeft()));
+        setGeometry(newGeometry);
+        break;
+    }
+    default:
+        break;
+    }
+    return DBlurEffectWidget::eventFilter(watched, event);
 }

--- a/src/widgets/roundpopupwidget.cpp
+++ b/src/widgets/roundpopupwidget.cpp
@@ -15,14 +15,13 @@ RoundPopupWidget::RoundPopupWidget(QWidget *parent)
     : DBlurEffectWidget(parent)
     , m_pContentWidget(nullptr)
     , m_mainLayout(new QVBoxLayout())
+    , m_savedParent(this)
 {
     initUI();
 }
 
 void RoundPopupWidget::initUI()
 {
-    setBlurEnabled(true);
-    setBlendMode(DBlurEffectWidget::InWidgetBlend);
     setBlurRectXRadius(RADIUS);
     setBlurRectYRadius(RADIUS);
     setMaskColor(QColor(238, 238, 238, 0.8 * 255));
@@ -33,22 +32,22 @@ void RoundPopupWidget::initUI()
 
 void RoundPopupWidget::setContent(QWidget *widget)
 {
+    if (widget != m_pContentWidget && m_pContentWidget) {
+        m_mainLayout->removeWidget(m_pContentWidget);
+        m_pContentWidget->setParent(m_savedParent);
+        m_pContentWidget->hide();
+        m_savedParent = this;
+    }
+
     if (!widget)
         return;
 
     setFixedSize(widget->size() + QSize(MARGIN * 2, MARGIN * 2));
-
-    if (m_pContentWidget != widget) {
-        if (m_pContentWidget) {
-          m_mainLayout->removeWidget(m_pContentWidget);
-          m_pContentWidget->setVisible(false);
-        }
-
-        m_mainLayout->addWidget(widget);
-    }
-
+    if (widget->parentWidget() != this)
+        m_savedParent = widget->parentWidget();
+    m_mainLayout->addWidget(widget);
     m_pContentWidget = widget;
-    widget->setVisible(true);
+    widget->show();
 }
 
 QWidget *RoundPopupWidget::getContent() const
@@ -58,8 +57,6 @@ QWidget *RoundPopupWidget::getContent() const
 
 void RoundPopupWidget::hideEvent(QHideEvent *event)
 {
-    if (m_pContentWidget)
-        m_pContentWidget->hide();
-
+    setContent(nullptr);
     QWidget::hideEvent(event);
 }

--- a/src/widgets/roundpopupwidget.h
+++ b/src/widgets/roundpopupwidget.h
@@ -26,6 +26,7 @@ public:
 
 protected:
     void hideEvent(QHideEvent *event) Q_DECL_OVERRIDE;
+    bool eventFilter(QObject *watched, QEvent *event) override;
 
 private:
     void initUI();

--- a/src/widgets/roundpopupwidget.h
+++ b/src/widgets/roundpopupwidget.h
@@ -33,6 +33,7 @@ private:
 private:
     QWidget *m_pContentWidget;
     QVBoxLayout *m_mainLayout;
+    QWidget *m_savedParent;
 };
 
 


### PR DESCRIPTION
Network panel used to be controlled by dss-network-plugin, click
button simply show the panel. Let panel controlled by dde-session-shell.
dss-network-plugin just return its content. Use a fake popup instead of
a popup window.