### PR TITLE
fix: wrong height for bottom frame

### DIFF
--- a/src/session-widgets/sessionbasewindow.cpp
+++ b/src/session-widgets/sessionbasewindow.cpp
@@ -60,7 +60,7 @@ void SessionBaseWindow::setCenterBottomWidget(QWidget *const widget)
         m_centerBottomLayout->removeWidget(m_centerBottomWidget);
     }
 
-    m_centerBottomLayout->addWidget(widget, 0, Qt::AlignCenter);
+    m_centerBottomLayout->addWidget(widget, 0, Qt::AlignBottom | Qt::AlignHCenter);
     m_centerBottomWidget = widget;
 
 #ifdef QT_DEBUG
@@ -161,7 +161,7 @@ void SessionBaseWindow::initUI()
 
     m_bottomFrame->setAccessibleName("BottomFrame");
     m_bottomFrame->setLayout(bottomLayout);
-    m_bottomFrame->setFixedHeight(autoScaledSize(LOCK_CONTENT_TOPBOTTOM_WIDGET_HEIGHT));
+    m_bottomFrame->setFixedHeight(LOCK_CONTENT_TOPBOTTOM_WIDGET_HEIGHT);
     m_bottomFrame->setAutoFillBackground(false);
 
     m_mainLayout->setContentsMargins(getMainLayoutMargins());
@@ -207,7 +207,7 @@ void SessionBaseWindow::resizeEvent(QResizeEvent *event)
 {
     m_mainLayout->setContentsMargins(getMainLayoutMargins());
     m_TopFrame->setFixedHeight(autoScaledSize(LOCK_CONTENT_TOPBOTTOM_WIDGET_HEIGHT));
-    m_bottomFrame->setFixedHeight(autoScaledSize(LOCK_CONTENT_TOPBOTTOM_WIDGET_HEIGHT));
+    m_bottomFrame->setFixedHeight(LOCK_CONTENT_TOPBOTTOM_WIDGET_HEIGHT);
     m_fakeWindowLayer->setFixedSize(size());
 
     QFrame::resizeEvent(event);

--- a/src/widgets/mediawidget.cpp
+++ b/src/widgets/mediawidget.cpp
@@ -18,12 +18,10 @@ void MediaWidget::initUI()
 {
     m_dmprisWidget = new DMPRISControl;
     m_dmprisWidget->setAccessibleName("MPRISWidget");
-    m_dmprisWidget->setFixedWidth(200);
     m_dmprisWidget->setPictureVisible(false);
-
-    QHBoxLayout *mainlayout = new QHBoxLayout;
-
-    mainlayout->addWidget(m_dmprisWidget, 0, Qt::AlignBottom);
+    QVBoxLayout *mainlayout = new QVBoxLayout;
+    mainlayout->setMargin(1);
+    mainlayout->addWidget(m_dmprisWidget);
 
     setLayout(mainlayout);
 


### PR DESCRIPTION
Fix height for bottom frame and do not change with the screen height. Calculate the fixed height according to scale ratio.

Log: fix wrong height for bottom frame