### PR TITLE
fix: remove unnecessary margin in mediawidget

### DIFF
--- a/src/widgets/mediawidget.cpp
+++ b/src/widgets/mediawidget.cpp
@@ -20,7 +20,7 @@ void MediaWidget::initUI()
     m_dmprisWidget->setAccessibleName("MPRISWidget");
     m_dmprisWidget->setPictureVisible(false);
     QVBoxLayout *mainlayout = new QVBoxLayout;
-    mainlayout->setMargin(1);
+    mainlayout->setMargin(0);
     mainlayout->addWidget(m_dmprisWidget);
 
     setLayout(mainlayout);


### PR DESCRIPTION
There should not be any margin in order that media control button is aligned with controlwidget floating buttons.

Log: remove unnecessary margin