### PR TITLE
fix: shadow error of tips widget

### DIFF
--- a/src/session-widgets/lockcontent.cpp
+++ b/src/session-widgets/lockcontent.cpp
@@ -26,7 +26,7 @@ using namespace dss::module;
 LockContent::LockContent(SessionBaseModel *const model, QWidget *parent)
     : SessionBaseWindow(parent)
     , m_model(model)
-    , m_controlWidget(new ControlWidget(m_model))
+    , m_controlWidget(new ControlWidget(m_model, this))
     , m_logoWidget(new LogoWidget(this))
     , m_timeWidget(new TimeWidget(this))
     , m_userListWidget(nullptr)

--- a/src/widgets/controlwidget.cpp
+++ b/src/widgets/controlwidget.cpp
@@ -30,6 +30,7 @@
 
 #define BUTTON_ICON_SIZE QSize(26,26)
 #define BUTTON_SIZE QSize(52,52)
+static constexpr int TipsBottomDistance = 10;
 
 using namespace dss;
 DCORE_USE_NAMESPACE
@@ -264,13 +265,15 @@ void ControlWidget::addModule(module::BaseModuleInterface *module)
         if (trayModule->itemTipsWidget()) {
             m_tipsWidget->setContent(trayModule->itemTipsWidget());
             QPoint p = m_tipsWidget->parentWidget() ? m_tipsWidget->parentWidget()->mapFromGlobal(mapToGlobal(button->pos())) : mapToGlobal(button->pos());
-            m_tipsWidget->show(p.x() + button->width() / 2, p.y());
+            m_tipsWidget->show(p.x() + button->width() / 2, p.y() - TipsBottomDistance);
         }
     });
 
     connect(button, &FloatingButton::requestHideTips, this, [ = ] {
-        if (m_tipsWidget->getContent())
+        if (m_tipsWidget->getContent()) {
             m_tipsWidget->getContent()->setVisible(false);
+            m_tipsWidget->setContent(nullptr);
+        }
         m_tipsWidget->hide();
     });
 
@@ -520,13 +523,15 @@ void ControlWidget::showInfoTips()
     m_tipContentWidget->setText(button->tipText());
     m_tipsWidget->setContent(m_tipContentWidget);
 
-    m_tipsWidget->show(mapToGlobal(button->pos()).x() + button->width() / 2, mapToGlobal(button->pos()).y());
+    QPoint p = m_tipsWidget->parentWidget() ? m_tipsWidget->parentWidget()->mapFromGlobal(mapToGlobal(button->pos())) : mapToGlobal(button->pos());
+    m_tipsWidget->show(p.x() + button->width() / 2, p.y() - TipsBottomDistance);
 }
 
 void ControlWidget::hideInfoTips()
 {
     if (m_tipsWidget->getContent()) {
         m_tipsWidget->getContent()->setVisible(false);
+        m_tipsWidget->setContent(nullptr);
     }
 
     m_tipsWidget->hide();

--- a/src/widgets/tipswidget.h
+++ b/src/widgets/tipswidget.h
@@ -5,22 +5,29 @@
 #ifndef TIPSWIDGET_H
 #define TIPSWIDGET_H
 
-#include <DArrowRectangle>
+#include <DBlurEffectWidget>
+#include <QPointer>
 
-class TipsWidget : public Dtk::Widget::DArrowRectangle
+class TipsWidget : public Dtk::Widget::DBlurEffectWidget
 {
 public:
     explicit TipsWidget(QWidget *parent = nullptr);
     void setContent(QWidget *content);
+    inline QWidget *getContent() const { return m_content; }
+    void resizeFromContent();
 
 public slots:
-    void show(int x, int y) override;
+    /*!
+     * @brief slot to show the tips widget, x and y is for bottom center point of the widget
+     */
+    void show(int x, int y);
 
 protected:
     bool eventFilter(QObject *o, QEvent *e) override;
 
 protected:
     QPoint m_lastPos;
+    QPointer<QWidget> m_content;
 };
 
 #endif // TIPSWIDGET_H


### PR DESCRIPTION
There are some problems with window manager shadow. Replace base class of TipsWidget with DBlurEffectWidget. Do not depend on wm.

Log: fix shadow error of tips widget
Issue: https://github.com/linuxdeepin/developer-center/issues/4298