### PR TITLE
chore: add option for contrast background

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ set(CMAKE_C_FLAGS, "${CMAKE_C_FLAGS} ${SECURITY_COMPILE}")
 # coverage option
 # cmake -DENABLE_COVERAGE=ON ..
 OPTION (ENABLE_COVERAGE "Use gcov" OFF)
+option (CONTRAST_BACKGROUND "Fill background using high-contrast color for debug" OFF)
 MESSAGE(STATUS ENABLE_COVERAGE=${ENABLE_COVERAGE})
 if (ENABLE_COVERAGE)
     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage")
@@ -310,6 +311,11 @@ target_link_libraries(lightdm-deepin-greeter PRIVATE
     ${Greeter_LIBRARIES}
     ${DEEPIN_PW_CHECK}
 )
+
+if(CONTRAST_BACKGROUND)
+    target_compile_definitions(dde-lock PRIVATE CONTRAST_BACKGROUND)
+    target_compile_definitions(lightdm-deepin-greeter PRIVATE CONTRAST_BACKGROUND)
+endif()
 
 # plugins
 add_subdirectory(modules)

--- a/src/lightdm-deepin-greeter/changepasswordwidget.cpp
+++ b/src/lightdm-deepin-greeter/changepasswordwidget.cpp
@@ -343,7 +343,7 @@ void ChangePasswordWidget::parseProcessResult(int exitCode, const QString &outpu
 
 void ChangePasswordWidget::paintEvent(QPaintEvent *event)
 {
-#ifdef QT_DEBUG
+#ifdef CONTRAST_BACKGROUND
     Q_UNUSED(event);
 
     QPainter painter(this);

--- a/src/session-widgets/auth_widget.cpp
+++ b/src/session-widgets/auth_widget.cpp
@@ -525,7 +525,7 @@ void AuthWidget::showEvent(QShowEvent *event)
 
 void AuthWidget::paintEvent(QPaintEvent *event)
 {
-#ifdef QT_DEBUG
+#ifdef CONTRAST_BACKGROUND
     Q_UNUSED(event);
 
     QPainter painter(this);

--- a/src/session-widgets/sessionbasewindow.cpp
+++ b/src/session-widgets/sessionbasewindow.cpp
@@ -46,7 +46,7 @@ void SessionBaseWindow::setLeftBottomWidget(QWidget * const widget)
     m_leftBottomLayout->addWidget(widget, 0, Qt::AlignBottom);
     m_leftBottomWidget = widget;
 
-#ifdef QT_DEBUG
+#ifdef CONTRAST_BACKGROUND
     m_leftBottomWidget->setStyleSheet("background-color: darkRed");
 #endif
 }
@@ -63,7 +63,7 @@ void SessionBaseWindow::setCenterBottomWidget(QWidget *const widget)
     m_centerBottomLayout->addWidget(widget, 0, Qt::AlignBottom | Qt::AlignHCenter);
     m_centerBottomWidget = widget;
 
-#ifdef QT_DEBUG
+#ifdef CONTRAST_BACKGROUND
     m_centerBottomWidget->setStyleSheet("background-color: darkGreen");
 #endif
 }
@@ -80,7 +80,7 @@ void SessionBaseWindow::setRightBottomWidget(QWidget * const widget)
     m_rightBottomLayout->addWidget(widget, 0, Qt::AlignBottom);
     m_rightBottomWidget = widget;
 
-#ifdef QT_DEBUG
+#ifdef CONTRAST_BACKGROUND
     m_rightBottomWidget->setStyleSheet("background-color: darkBlue");
 #endif
 }
@@ -170,7 +170,7 @@ void SessionBaseWindow::initUI()
     m_mainLayout->addWidget(m_centerFrame);
     m_mainLayout->addWidget(m_bottomFrame);
 
-#ifdef QT_DEBUG
+#ifdef CONTRAST_BACKGROUND
     m_TopFrame->setStyleSheet("background-color: darkGray");
     m_bottomFrame->setStyleSheet("background-color: gray");
 #endif


### PR DESCRIPTION
Contrast background will sometimes disturb debugging. Use a separate option to control its presence instead of using QT_DEBUG.