### PR TITLE
fix: session miss when da changes

### DIFF
--- a/src/dde-lock/lockworker.h
+++ b/src/dde-lock/lockworker.h
@@ -52,6 +52,7 @@ public slots:
     void restartResetSessionTimer();
     void onAuthFinished();
     void onAuthStateChanged(const int type, const int state, const QString &message);
+    void onFrameworkStateChanged(const int state);
 
     void disableGlobalShortcutsForWayland(const bool enable);
 

--- a/src/libdde-auth/deepinauthframework.h
+++ b/src/libdde-auth/deepinauthframework.h
@@ -105,6 +105,7 @@ private:
 
 private:
     AuthInter *m_authenticateInter;
+    QDBusServiceWatcher *m_watcher;
     pthread_t m_PAMAuthThread;
     QString m_account;
     QString m_message;
@@ -116,6 +117,7 @@ private:
     QMap<QString, AuthControllerInter *> *m_authenticateControllers;
     bool m_cancelAuth;
     bool m_waitToken;
+    bool m_retryActivateFramework;
 
     void *m_encryptionHandle;
     FUNC_AES_CBC_ENCRYPT m_F_AES_cbc_encrypt;


### PR DESCRIPTION
When deepin-authenticate's state changes(This means that we have lost the session), we should just destroy all authentication and then recover it.
Notice that, as dde-session-shell prefers deepin-authenticate, it will try to activate deepin-authenticate once when deepin-authen- ticate unregister the service.

Log: fix session miss when da changes
Issue: https://github.com/linuxdeepin/developer-center/issues/5325