### PR TITLE
fix: no translation for time in greeter

### DIFF
--- a/src/session-widgets/lockcontent.cpp
+++ b/src/session-widgets/lockcontent.cpp
@@ -78,6 +78,9 @@ LockContent::LockContent(SessionBaseModel *const model, QWidget *parent)
         }
     }
     once = true;
+
+    QString localeName = regionValue(localeName_key);
+    m_timeWidget->updateLocale(QLocale(localeName));
 }
 
 void LockContent::initUI()
@@ -294,7 +297,7 @@ void LockContent::onCurrentUserChanged(std::shared_ptr<User> user)
     m_user = user;
 
     m_localeName = regionValue(localeName_key);
-    QLocale locale = m_localeName.isEmpty()? QLocale::system() : QLocale(m_localeName);
+    QLocale locale = m_localeName.isEmpty()? user->locale() : QLocale(m_localeName);
     m_shortTimeFormat = regionValue(shortTimeFormat_key);
     m_longDateFormat = regionValue(longDateFormat_key);
     buildConnect();

--- a/src/widgets/timewidget.cpp
+++ b/src/widgets/timewidget.cpp
@@ -63,7 +63,7 @@ void TimeWidget::set24HourFormat(bool use24HourFormat)
 
 void TimeWidget::updateLocale(const QLocale &locale, const QString &shortTimeFormat, const QString &longDateFormat)
 {
-    m_locale = locale;
+    m_locale = locale.name().isEmpty() ? QLocale::system() : locale;
     if (!shortTimeFormat.isEmpty())
         m_shortTimeFormat = shortTimeFormat;
     if (!longDateFormat.isEmpty())


### PR DESCRIPTION
Set locale to the current user's locale when firstly entering system

Issue: https://github.com/linuxdeepin/developer-center/issues/6994