### PR TITLE
fix: default locale for time

### DIFF
--- a/src/session-widgets/lockcontent.cpp
+++ b/src/session-widgets/lockcontent.cpp
@@ -80,7 +80,7 @@ LockContent::LockContent(SessionBaseModel *const model, QWidget *parent)
     once = true;
 
     QString localeName = regionValue(localeName_key);
-    m_timeWidget->updateLocale(QLocale(localeName));
+    m_timeWidget->updateLocale(localeName);
 }
 
 void LockContent::initUI()
@@ -220,7 +220,7 @@ void LockContent::onValueChanged(const QDBusMessage &dbusMessage)
     } else if (interfaceName == longDateFormat_key) {
         m_longDateFormat = regionValue(longDateFormat_key);
     }
-    m_timeWidget->updateLocale(QLocale(m_localeName), m_shortTimeFormat, m_longDateFormat);
+    m_timeWidget->updateLocale(m_localeName, m_shortTimeFormat, m_longDateFormat);
 }
 
 QString LockContent::configPath(std::shared_ptr<User> user) const
@@ -304,7 +304,7 @@ void LockContent::onCurrentUserChanged(std::shared_ptr<User> user)
 
     auto logoLocale = qApp->applicationName() == "dde-lock" ? QLocale::system().name() : user->locale();
     m_logoWidget->updateLocale(logoLocale);
-    m_timeWidget->updateLocale(locale, m_shortTimeFormat, m_longDateFormat);
+    m_timeWidget->updateLocale(locale.name(), m_shortTimeFormat, m_longDateFormat);
 
     m_timeWidget->set24HourFormat(user->isUse24HourFormat());
     m_timeWidget->setWeekdayFormatType(user->weekdayFormat());

--- a/src/widgets/timewidget.cpp
+++ b/src/widgets/timewidget.cpp
@@ -61,9 +61,9 @@ void TimeWidget::set24HourFormat(bool use24HourFormat)
     refreshTime();
 }
 
-void TimeWidget::updateLocale(const QLocale &locale, const QString &shortTimeFormat, const QString &longDateFormat)
+void TimeWidget::updateLocale(const QString &locale, const QString &shortTimeFormat, const QString &longDateFormat)
 {
-    m_locale = locale.name().isEmpty() ? QLocale::system() : locale;
+    m_locale = locale.isEmpty() ? QLocale::system() : QLocale(locale);
     if (!shortTimeFormat.isEmpty())
         m_shortTimeFormat = shortTimeFormat;
     if (!longDateFormat.isEmpty())

--- a/src/widgets/timewidget.h
+++ b/src/widgets/timewidget.h
@@ -20,7 +20,7 @@ public:
     explicit TimeWidget(QWidget *parent = nullptr);
     inline bool get24HourFormat() const { return m_use24HourFormat; }
     void set24HourFormat(bool use24HourFormat);
-    void updateLocale(const QLocale &locale, const QString &shortTimeFormat = "", const QString &longDateFormat = "");
+    void updateLocale(const QString &locale, const QString &shortTimeFormat = "", const QString &longDateFormat = "");
 
 public Q_SLOTS:
     void setWeekdayFormatType(int type);


### PR DESCRIPTION
fix: default locale for time

Dont verify the locale directly, verify the string.

Issue: https://github.com/linuxdeepin/developer-center/issues/6994