### PR TITLE
fix: black circle in PasswordEdit

### DIFF
--- a/src/session-widgets/auth_password.cpp
+++ b/src/session-widgets/auth_password.cpp
@@ -65,6 +65,9 @@ void AuthPassword::initUI()
     m_passwordEdit->setFocusPolicy(Qt::StrongFocus);
     m_passwordEdit->lineEdit()->setAlignment(Qt::AlignCenter);
     m_passwordEdit->lineEdit()->setValidator(new QRegExpValidator(QRegExp("^[ -~]+$")));
+    m_passwordFont = m_passwordEdit->lineEdit()->font();
+    m_passwordFont.setPixelSize(6);
+    m_passwordFont.setLetterSpacing(m_passwordFont.letterSpacingType(), 200);
 
     setLineEditInfo(tr("Password"), PlaceHolderText);
 
@@ -594,12 +597,17 @@ void AuthPassword::updateResetPasswordUI()
 
 bool AuthPassword::eventFilter(QObject *watched, QEvent *event)
 {
-    if (qobject_cast<DLineEditEx *>(watched) == m_passwordEdit && event->type() == QEvent::KeyPress) {
-        QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
-        if (keyEvent->matches(QKeySequence::Cut)
-            || keyEvent->matches(QKeySequence::Copy)
-            || keyEvent->matches(QKeySequence::Paste)) {
-            return true;
+    if (qobject_cast<DLineEditEx *>(watched) == m_passwordEdit) {
+        if (event->type() == QEvent::KeyPress) {
+            QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
+            if (keyEvent->matches(QKeySequence::Cut)
+                || keyEvent->matches(QKeySequence::Copy)
+                || keyEvent->matches(QKeySequence::Paste)) {
+              return true;
+            }
+        } else if (event->type() == QEvent::Paint) {
+          m_passwordEdit->lineEdit()->echoMode() == QLineEdit::Password ?
+              m_passwordEdit->lineEdit()->setFont(m_passwordFont) : m_passwordEdit->lineEdit()->setFont(m_passwordEdit->font());
         }
     }
     return false;

--- a/src/session-widgets/auth_password.h
+++ b/src/session-widgets/auth_password.h
@@ -76,6 +76,7 @@ private:
     DFloatingMessage *m_resetPasswordFloatingMessage;
     uid_t m_currentUid; // 当前用户uid
     QTimer *m_bindCheckTimer;
+    QFont m_passwordFont;
 };
 
 #endif // AUTHPASSWORD_H


### PR DESCRIPTION
set the size of black circle to 6 pixel by changing the font, 
set the letter spacing to 200 under PercentageSpacing type. 

Issue: linuxdeepin/developer-center#7335