### PR TITLE
chore: lock button focus policy tweak

### DIFF
--- a/src/session-widgets/auth_widget.cpp
+++ b/src/session-widgets/auth_widget.cpp
@@ -97,6 +97,8 @@ void AuthWidget::initUI()
 
     /* 解锁按钮 */
     m_lockButton = new DFloatingButton(this);
+    m_lockButton->setFocusPolicy(Qt::StrongFocus);
+
     if (m_model->appType() == Lock) {
         m_lockButton->setIcon(DStyle::SP_LockElement);
     } else {


### PR DESCRIPTION
点击解锁按钮时焦点聚焦到解锁按钮
方便无密码解锁时，切换焦点后点击解锁，再次锁屏可以直接回车解锁。。

Issue: https://github.com/linuxdeepin/developer-center/issues/6876