### PR TITLE
fix: can't login after recreating user

### DIFF
--- a/src/lightdm-deepin-greeter/greeterworker.cpp
+++ b/src/lightdm-deepin-greeter/greeterworker.cpp
@@ -345,20 +345,17 @@ void GreeterWorker::switchToUser(std::shared_ptr<User> user)
     if (user->uid() == INT_MAX) {
         m_model->setAuthType(AT_None);
     }
-    if (user->isLogin()) { // switch to user Xorg
-        QProcess::startDetached("dde-switchtogreeter", QStringList() << user->name());
+
+    setCurrentUser(user);
+    m_model->updateAuthState(AT_All, AS_Cancel, "Cancel");
+    destroyAuthentication(m_account);
+    m_model->updateCurrentUser(user);
+    if (!user->isNoPasswordLogin()) {
+        createAuthentication(user->name());
     } else {
-        setCurrentUser(user);
-        m_model->updateAuthState(AT_All, AS_Cancel, "Cancel");
-        destroyAuthentication(m_account);
-        m_model->updateCurrentUser(user);
-        if (!user->isNoPasswordLogin()) {
-            createAuthentication(user->name());
-        } else {
-            m_model->setAuthType(AT_None);
-        }
-        m_soundPlayerInter->PrepareShutdownSound(static_cast<int>(m_model->currentUser()->uid()));
+        m_model->setAuthType(AT_None);
     }
+    m_soundPlayerInter->PrepareShutdownSound(static_cast<int>(m_model->currentUser()->uid()));
 }
 
 bool GreeterWorker::isSecurityEnhanceOpen()

--- a/src/session-widgets/auth_widget.cpp
+++ b/src/session-widgets/auth_widget.cpp
@@ -99,7 +99,7 @@ void AuthWidget::initUI()
     m_lockButton = new DFloatingButton(this);
     m_lockButton->setFocusPolicy(Qt::StrongFocus);
 
-    if (m_model->appType() == Lock) {
+    if (m_user->isLogin()) {
         m_lockButton->setIcon(DStyle::SP_LockElement);
     } else {
         m_lockButton->setIcon(DStyle::SP_ArrowNext);
@@ -187,6 +187,12 @@ void AuthWidget::setUser(std::shared_ptr<User> user)
     }
     if (m_passwordAuth) {
         m_passwordAuth->setCurrentUid(user->uid());
+    }
+
+    if (user->isLogin()) {
+        m_lockButton->setIcon(DStyle::SP_LockElement);
+    } else {
+        m_lockButton->setIcon(DStyle::SP_ArrowNext);
     }
 }
 
@@ -340,10 +346,10 @@ void AuthWidget::setLockButtonType(const int type)
         lockPalette.setColor(QPalette::Highlight, ShutdownColor);
         break;
     default:
-        if (m_model->appType() == Login) {
-            m_lockButton->setIcon(DStyle::SP_ArrowNext);
-        } else {
+        if (m_user->isLogin()) {
             m_lockButton->setIcon(DStyle::SP_LockElement);
+        } else {
+            m_lockButton->setIcon(DStyle::SP_ArrowNext);
         }
         break;
     }


### PR DESCRIPTION
  * 切换回已登录账户时，使用 lightdm 的验证流程， 而不是切换 tty
  * 按钮是解锁样式还是登录样式改为根据用户状态判断， 而不是根据是锁屏还是 greeter 判断

Issues: linuxdeepin/developer-center#6512