### PR TITLE
fix: password level hint not visible

### DIFF
--- a/src/global_util/constants.h
+++ b/src/global_util/constants.h
@@ -55,6 +55,8 @@ enum AuthFactorType {
 };
 }
 
+static constexpr int LINEEDIT_SPACING = 30;
+
 namespace Popup
 {
 static constexpr int HorizontalMargin = 10;

--- a/src/lightdm-deepin-greeter/changepasswordwidget.cpp
+++ b/src/lightdm-deepin-greeter/changepasswordwidget.cpp
@@ -76,8 +76,6 @@ void ChangePasswordWidget::initUI()
     m_newPasswdEdit->setFixedSize(PASSWDLINEEIDT_WIDTH, PASSWDLINEEDIT_HEIGHT);
 
     m_levelWidget->reset();
-    // TODO 后续调整
-    //    m_levelWidget->setMaximumHeight(10);
 
     m_repeatPasswdEdit->setClearButtonEnabled(false);
     m_repeatPasswdEdit->setEchoMode(QLineEdit::Password);
@@ -99,22 +97,19 @@ void ChangePasswordWidget::initUI()
     m_mainLayout->addWidget(m_avatar, 0, Qt::AlignCenter);
     m_mainLayout->addWidget(m_nameLabel, 0, Qt::AlignCenter);
     m_mainLayout->addWidget(m_tipsLabel, 0, Qt::AlignCenter);
-    m_mainLayout->addWidget(m_oldPasswdEdit, 0, Qt::AlignCenter);
-    QWidget *newPasswdWidget = new QWidget;
-    m_newPasswdEdit->setParent(newPasswdWidget);
-    m_levelWidget->setParent(newPasswdWidget);
-    auto passwdLevelSizeHint = m_levelWidget->sizeHint();
-    newPasswdWidget->setFixedSize(PASSWDLINEEIDT_WIDTH + 2 * passwdLevelSizeHint.width(), PASSWDLINEEDIT_HEIGHT);
-    m_mainLayout->addWidget(newPasswdWidget, 0, Qt::AlignCenter);
-    auto passwdAnchor = new DAnchors<DPasswordEdit>(m_newPasswdEdit);
-    auto levelAnchor = new DAnchors<PasswordLevelWidget>(m_levelWidget);
-    auto newPasswdWidgetAnchor = new DAnchors<QWidget>(newPasswdWidget);
-    passwdAnchor->setCenterIn(newPasswdWidgetAnchor);
-    levelAnchor->setVerticalCenter(passwdAnchor->verticalCenter());
-    levelAnchor->setLeftMargin(2);
-    levelAnchor->setLeft(passwdAnchor->right());
-    m_mainLayout->addWidget(m_repeatPasswdEdit, 0, Qt::AlignCenter);
-    m_mainLayout->addWidget(m_passwordHints, 0, Qt::AlignCenter);
+    auto lineEditWidget = new QWidget;
+    auto lineEditLayout = new QVBoxLayout(lineEditWidget);
+    lineEditLayout->setMargin(0);
+    lineEditLayout->setSpacing(0);
+    lineEditLayout->addWidget(m_oldPasswdEdit, 0, Qt::AlignCenter);
+    m_levelWidget->setMinimumHeight(LINEEDIT_SPACING);
+    lineEditLayout->addWidget(m_levelWidget, 0, Qt::AlignRight);
+    lineEditLayout->addWidget(m_newPasswdEdit, 0, Qt::AlignCenter);
+    lineEditLayout->addSpacing(LINEEDIT_SPACING);
+    lineEditLayout->addWidget(m_repeatPasswdEdit, 0, Qt::AlignCenter);
+    lineEditLayout->addSpacing(LINEEDIT_SPACING);
+    lineEditLayout->addWidget(m_passwordHints, 0, Qt::AlignCenter);
+    m_mainLayout->addWidget(lineEditWidget, 0, Qt::AlignCenter);
     m_mainLayout->addWidget(m_okBtn, 0, Qt::AlignCenter);
     m_okBtn->setFixedWidth(160);
 

--- a/src/lightdm-deepin-greeter/passwordlevelwidget.cpp
+++ b/src/lightdm-deepin-greeter/passwordlevelwidget.cpp
@@ -21,11 +21,6 @@ PasswordLevelWidget::PasswordLevelWidget(QWidget *parent)
 {
     initUI();
     initConnections();
-
-#ifndef QT_DEBUG
-    // TODO 高度超出可显示的区域，导致显示异常，暂时屏蔽，具体的显示方式还在确认
-    m_tips->setVisible(false);
-#endif
 }
 
 void PasswordLevelWidget::reset()
@@ -96,7 +91,7 @@ void PasswordLevelWidget::initUI()
     m_layout->addWidget(m_lowIcon);
     m_layout->addWidget(m_mediumIcon);
     m_layout->addWidget(m_highIcon);
-
+    m_layout->setMargin(0);
     setLayout(m_layout);
 }
 


### PR DESCRIPTION
 * Adjust change password widget layout, add spacing.
 * Show level hint in release mode. Do not shield it.

Log: fix password level hint not visible
Issue: https://github.com/linuxdeepin/developer-center/issues/5588
Influence: https://github.com/linuxdeepin/dde-session-shell/issues/302