### PR TITLE
fix: alert and hint disappear when hide

### DIFF
--- a/src/session-widgets/auth_password.cpp
+++ b/src/session-widgets/auth_password.cpp
@@ -117,7 +117,6 @@ void AuthPassword::initConnections()
     connect(m_togglePasswordBtn, &DIconButton::clicked, this, &AuthPassword::togglePassword);
     /* 密码输入框 */
     connect(m_passwordEdit, &DLineEditEx::focusChanged, this, [this](const bool focus) {
-        if (!focus) m_passwordEdit->setAlert(false);
         m_authStateLabel->setVisible(!focus && m_showAuthState);
         emit focusChanged(focus);
     });
@@ -607,9 +606,5 @@ bool AuthPassword::eventFilter(QObject *watched, QEvent *event)
 
 void AuthPassword::hideEvent(QHideEvent *event)
 {
-    m_passwordEdit->setAlert(false);
-    m_passwordEdit->hideAlertMessage();
-    setLineEditInfo(tr("Password"), PlaceHolderText);
-    closeResetPasswordMessage();
     AuthModule::hideEvent(event);
 }

--- a/src/session-widgets/auth_ukey.cpp
+++ b/src/session-widgets/auth_ukey.cpp
@@ -325,8 +325,5 @@ bool AuthUKey::eventFilter(QObject *watched, QEvent *event)
 
 void AuthUKey::hide()
 {
-    m_lineEdit->setAlert(false);
-    m_lineEdit->hideAlertMessage();
-    setLineEditInfo(tr("Enter your PIN"), PlaceHolderText);
     AuthModule::hide();
 }


### PR DESCRIPTION
In hideEvent, auth module hide alert message and reset line edit placeholder text deliberately. Just leave its state.

Log: fix alert and hint disappear when hide
Issue: https://github.com/linuxdeepin/developer-center/issues/5622
Related-to: 0b690e20e71c1d4e69628fd3930bb3b7030fceca
Depends-on: https://github.com/linuxdeepin/dtkwidget/pull/559