### PR TITLE
fix: abnormal when background pixmap missing

### DIFF
--- a/src/widgets/fullscreenbackground.cpp
+++ b/src/widgets/fullscreenbackground.cpp
@@ -224,7 +224,7 @@ void FullscreenBackground::paintEvent(QPaintEvent *e)
     const QPixmap &blurBackground = getPixmap(PIXMAP_TYPE_BLUR_BACKGROUND);
 
     const QRect trueRect(QPoint(0, 0), QSize(size() * devicePixelRatioF()));
-    if (m_useSolidBackground) {
+    if (m_useSolidBackground || (background.isNull() && blurBackground.isNull())) {
         painter.fillRect(trueRect, QColor(DDESESSIONCC::SOLID_BACKGROUND_COLOR));
     } else {
         if (m_fadeOutAni) {


### PR DESCRIPTION
如果壁纸无效或者丢失了使用纯色背景，至少有个背景颜色吧

Issue: https://github.com/linuxdeepin/developer-center/issues/8546