### PR TITLE
fix: greeter unable to start

### DIFF
--- a/src/libdde-auth/deepinauthframework.h
+++ b/src/libdde-auth/deepinauthframework.h
@@ -119,7 +119,7 @@ private:
     bool m_waitToken;
     bool m_retryActivateFramework;
 
-    void *m_encryptionHandle;
+    QPointer<QLibrary>m_encryptionHandle;
     FUNC_AES_CBC_ENCRYPT m_F_AES_cbc_encrypt;
     FUNC_AES_SET_ENCRYPT_KEY m_F_AES_set_encrypt_key;
     FUNC_BIO_NEW m_F_BIO_new;


### PR DESCRIPTION
Reason: The SSL library name is incorrect and cannot be loaded use QLibrary load ssl library

Issue: https://github.com/linuxdeepin/developer-center/issues/8681