### PR TITLE
fix: 修复字体字号为20的时候锁屏界面切换用户列表文字被遮挡的问题

### DIFF
--- a/src/widgets/useritemdelegate.h
+++ b/src/widgets/useritemdelegate.h
@@ -31,6 +31,9 @@ public:
 
 public:
     explicit UserItemDelegate(QObject *parent = nullptr);
+    static int displayNameHeight();
+    static int nameHeight();
+    static int userTypeHeight();
 
 protected:
     void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const Q_DECL_OVERRIDE;

--- a/src/widgets/userlistpopupwidget.cpp
+++ b/src/widgets/userlistpopupwidget.cpp
@@ -179,9 +179,9 @@ void UserListPopupWidget::initUI()
     setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
     setEditTriggers(QAbstractItemView::NoEditTriggers);
-    setViewportMargins(0, 0, 0, 0);
+    setViewportMargins(5, 5, 5, 5);
     setMaximumHeight(MAX_HEIGHT);
-    setSpacing(ITEM_SPACING);
+    setSpacing(0);
 
     setItemDelegate(m_userItemDelegate);
     setModel(m_userItemModel);
@@ -203,6 +203,10 @@ void UserListPopupWidget::initConnections()
 
         qInfo() << "request switch user id:" << data.userId << " displayName:" << data.displayName;
         Q_EMIT requestSwitchToUser(m_model->findUserByUid(data.userId));
+    });
+
+    connect(qGuiApp, &QGuiApplication::fontChanged, this, [ this ] {
+        updateViewHeight();
     });
 }
 
@@ -308,7 +312,7 @@ void UserListPopupWidget::updateViewWidth()
 
 void UserListPopupWidget::updateViewHeight()
 {
-    int height = m_userItemModel->rowCount() * ITEM_HEIGHT + (m_userItemModel->rowCount() * 2) * ITEM_SPACING;
+    int height = m_userItemModel->rowCount() * getItemHeight();
     setFixedHeight(qMin(height, MAX_HEIGHT));
 }
 
@@ -325,4 +329,11 @@ QString UserListPopupWidget::accountStrType(int accountType) const
         default:
             return "";
     }
+}
+
+int UserListPopupWidget::getItemHeight()
+{
+    int height = ITEM_SPACING * 2 + UserItemDelegate::displayNameHeight() + 2 + UserItemDelegate::userTypeHeight() + ITEM_SPACING * 2;
+
+    return height > ITEM_HEIGHT ? height : ITEM_HEIGHT;
 }

--- a/src/widgets/userlistpopupwidget.h
+++ b/src/widgets/userlistpopupwidget.h
@@ -50,6 +50,7 @@ private:
     void updateViewWidth();
     void updateViewHeight();
     int calculateItemWidth();
+    int getItemHeight();
     int stringWidth(const QString &str, int fontSize, bool isBold = false);
 
 private:


### PR DESCRIPTION
监听字体字号改变信号，实时更新列表宽度

Log:
Bug: https://github.com/linuxdeepin/developer-center/issues/8873 Influence: 切换用户列表文字展示