### PR TITLE
fix: PlaceholderText is not centered

### DIFF
--- a/src/widgets/dlineeditex.cpp
+++ b/src/widgets/dlineeditex.cpp
@@ -127,7 +127,8 @@ void DLineEditEx::paintEvent(QPaintEvent *event)
         pa.setPen(col);
         QTextOption option;
         option.setAlignment(Qt::AlignCenter);
-        pa.drawText(lineEdit()->rect(), lineEdit()->placeholderText(), option);
+        QRect contentRect(lineEdit()->pos(), lineEdit()->size());
+        pa.drawText(contentRect, lineEdit()->placeholderText(), option);
     }
     QWidget::paintEvent(event);
 }


### PR DESCRIPTION
DLineEdit是组合控件, DLineEdit和QLineEdit的坐标系不同, 不能直接把QLineEdit的Rect作为绘制区域来使用

Bug: https://pms.uniontech.com/bug-view-277209.html