### PR TITLE
chore: bump version to 6.0.25

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-session-shell (6.0.25) unstable; urgency=medium
+
+  * fix: turning off 'Unlocking is required to wake up the computer' does not work
+  * fix: Time text changes with time zone
+
+ -- zsien <quezhiyong@deepin.org>  Fri, 29 Nov 2024 15:36:13 +0800
+
 dde-session-shell (6.0.24) unstable; urgency=medium
 
   * release 6.0.24


### PR DESCRIPTION
  * fix: turning off 'Unlocking is required to wake up the computer' does not wo rk
  * fix: Time text changes with time zone