### PR TITLE
fix: Unable to open control center

### DIFF
--- a/src/app/dde-lock.cpp
+++ b/src/app/dde-lock.cpp
@@ -165,7 +165,7 @@ int main(int argc, char *argv[])
         }
         QObject::connect(lockFrame, &LockFrame::requestCheckAccount, worker, &LockWorker::checkAccount);
         lockFrame->setVisible(model->visible());
-        emit lockService.Visible(true);
+        emit lockService.Visible(model->visible());
         return lockFrame;
     };
 


### PR DESCRIPTION
The network panel cannot open the control center
Triggering requestCheckAccount when inserting or removing screens However, the constant transmission of the dbus signal as' ture 'resulted in an error in the network panel's judgment of the lock screen interface display status

pms: BUG-307587