### PR TITLE
chore: remove startdde dependency

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-session-shell (6.0.32) unstable; urgency=medium
+
+  * chore: remove startdde dependency
+
+ -- fuleyi <fuleyi@uniontech.com>  Wed, 02 Apr 2025 11:28:22 +0800
+
 dde-session-shell (6.0.31) unstable; urgency=medium
 
   * fix: lock window just show background widget (#400)

--- a/debian/control
+++ b/debian/control
@@ -31,8 +31,7 @@ Package: dde-session-shell
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, ${dist:Depends},
  deepin-desktop-schemas (>=5.9.14),
- dde-daemon (>=5.13.12),
- startdde (>=5.8.9),
+ dde-daemon (>=6.1.26),
  x11-xserver-utils,
  deepin-authenticate(>=1.2.27),
  libssl3,


### PR DESCRIPTION
remove startdde dependency

Log: remove startdde dependency
pms: TASK-374777

## Summary by Sourcery

Chores:
- Remove startdde dependency from the project's Debian packaging configuration