### PR TITLE
chore: bump version to 6.0.33

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-session-shell (6.0.33) unstable; urgency=medium
+
+  * chore: Synchronize to 107x (#402)
+  * chore: sync base dde-session-shell repo (#404)
+
+ -- zhaoyingzhen <zhaoyingzhen@uniontech.com>  Thu, 10 Apr 2025 14:13:15 +0800
+
 dde-session-shell (6.0.32) unstable; urgency=medium
 
   * chore: remove startdde dependency


### PR DESCRIPTION
as title

Log: as title

## Summary by Sourcery

Chores:
- Bump the project version to 6.0.33 in the debian changelog.