### PR TITLE
chore: bump version to 6.0.35

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+dde-session-shell (6.0.35) unstable; urgency=medium
+
+  * chore: remove Depends="pbis-open"
+  * sync: from linuxdeepin/dde-session-shell
+  * sync: from linuxdeepin/dde-session-shell
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Tue, 29 Apr 2025 15:20:55 +0800
+
 dde-session-shell (6.0.34) unstable; urgency=medium
 
   * sync: from linuxdeepin/dde-session-shell (#406)


### PR DESCRIPTION
update changelog to 6.0.35

## Summary by Sourcery

Chores:
- Update `debian/changelog`.