### PR TITLE
chore: bump version to 6.0.36

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-session-shell (6.0.36) unstable; urgency=medium
+
+  * sync: from linuxdeepin/dde-session-shell
+  * sync: from linuxdeepin/dde-session-shell
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Thu, 08 May 2025 17:36:55 +0800
+
 dde-session-shell (6.0.35) unstable; urgency=medium
 
   * chore: remove Depends="pbis-open"


### PR DESCRIPTION
update changelog to 6.0.36

## Summary by Sourcery

Chores:
- Update project version to 6.0.36