### PR TITLE
chore: bump version to 6.0.38

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-session-shell (6.0.38) unstable; urgency=medium
+
+  * sync: from linuxdeepin/dde-session-shell
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Thu, 15 May 2025 21:30:55 +0800
+
 dde-session-shell (6.0.37) unstable; urgency=medium
 
   * sync: from linuxdeepin/dde-session-shell


### PR DESCRIPTION
as title

Log: as title

## Summary by Sourcery

Chores:
- Update Debian changelog version to 6.0.38