### PR TITLE
chore: bump version to 6.0.39

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-session-shell (6.0.39) unstable; urgency=medium
+
+  * sync: from linuxdeepin/dde-session-shell
+  * sync: from linuxdeepin/dde-session-shell
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Wed, 28 May 2025 17:17:55 +0800
+
 dde-session-shell (6.0.38) unstable; urgency=medium
 
   * sync: from linuxdeepin/dde-session-shell


### PR DESCRIPTION
as title

Log: as title

## Summary by Sourcery

Chores:
- Bump Debian package version to 6.0.39 and update changelog entry.