### PR TITLE
chore: bump version to 6.0.40

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-session-shell (6.0.40) unstable; urgency=medium
+
+  * sync: from linuxdeepin/dde-session-shell
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Thu, 12 Jun 2025 19:33:15 +0800
+
 dde-session-shell (6.0.39) unstable; urgency=medium
 
   * sync: from linuxdeepin/dde-session-shell


### PR DESCRIPTION
as title

Log: as title

## Summary by Sourcery

Chores:
- Update debian/changelog to release version 6.0.40