### PR TITLE
chore: bump version to 6.0.41

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-session-shell (6.0.41) unstable; urgency=medium
+
+  * chore: remove unused Spanish translation files
+
+ -- xionglinlin <xionglinlin@uniontech.com>  Mon, 23 Jun 2025 17:04:03 +0800
+
 dde-session-shell (6.0.40) unstable; urgency=medium
 
   * sync: from linuxdeepin/dde-session-shell


### PR DESCRIPTION
update changelog to 6.0.41

## Summary by Sourcery

Chores:
- Update Debian changelog to reflect version 6.0.41