### PR TITLE
fix: add hardening compiler flags in debian/rules

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -5,6 +5,9 @@
 #export DH_VERBOSE=1
 export QT_SELECT=5
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+export DEB_CFLAGS_MAINT_APPEND = -Wall
+export DEB_CXXFLAGS_MAINT_APPEND = -Wall
+export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack -Wl,-E
 
 include /usr/share/dpkg/default.mk
 SYSTYPE=Desktop


### PR DESCRIPTION
1. Added DEB_CFLAGS_MAINT_APPEND with -Wall for C compiler warnings
2. Added DEB_CXXFLAGS_MAINT_APPEND with -Wall for C++ compiler warnings
3. Added DEB_LDFLAGS_MAINT_APPEND with multiple security hardening flags:
   - --as-needed for linker optimization
   - -z relro for RELRO protection
   - -z now for immediate binding
   - -z noexecstack for non-executable stacks
   - -E for exporting symbols
4. These changes improve security and code quality by enabling additional warnings and linker protections

fix: 在 debian/rules 中添加编译器加固标志

1. 为 C 编译器添加 DEB_CFLAGS_MAINT_APPEND 并启用 -Wall 警告
2. 为 C++ 编译器添加 DEB_CXXFLAGS_MAINT_APPEND 并启用 -Wall 警告
3. 为链接器添加 DEB_LDFLAGS_MAINT_APPEND 包含多个安全加固标志：
   - --as-needed 用于链接器优化
   - -z relro 用于 RELRO 保护
   - -z now 用于立即绑定
   - -z noexecstack 用于非可执行栈
   - -E 用于导出符号
4. 这些更改通过启用额外的警告和链接器保护来提高安全性和代码质量

## Summary by Sourcery

Enable additional compiler warnings and linker hardening flags in debian packaging to improve security and code quality

Build:
- Append '-Wall' to DEB_CFLAGS_MAINT_APPEND for C compiler warnings
- Append '-Wall' to DEB_CXXFLAGS_MAINT_APPEND for C++ compiler warnings
- Append security hardening flags (--as-needed, -z relro, -z now, -z noexecstack, -E) to DEB_LDFLAGS_MAINT_APPEND