### PR TITLE
chore: bump version to 6.0.42

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-session-shell (6.0.42) unstable; urgency=medium
+
+  * fix: add hardening compiler flags in debian/rules
+
+ -- WuJiangYu <wujiangyu@uniontech.com>  Thu, 03 Jul 2025 19:55:52 +0800
+
 dde-session-shell (6.0.41) unstable; urgency=medium
 
   * chore: remove unused Spanish translation files


### PR DESCRIPTION
update changelog to 6.0.42

## Summary by Sourcery

Chores:
- Bump Debian package version to 6.0.42 and update changelog