### PR TITLE
chore: bump version to 6.0.45

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,19 @@
+dde-session-shell (6.0.45) unstable; urgency=medium
+
+  * Sync: from linuxdeepin/dde-session-shell
+  * Chore: bump version to 6.0.44
+  * Sync: from linuxdeepin/dde-session-shell
+  * Sync: from linuxdeepin/dde-session-shell
+  - Updated configs/org.deepin.dde.lock.json
+  * Fix: update homepage url in debian/control
+  * Sync: from linuxdeepin/dde-session-shell
+  * Chore: bump version to 6.0.43
+  * Sync: from linuxdeepin/dde-session-shell
+  * Chore: remove unused Spanish translation files
+  * Sync: from linuxdeepin/dde-session-shell
+
+ -- zyz <zhaoyingzhen@uniontech.com>  Thu, 28 Aug 2025 18:29:17 +0800
+
 dde-session-shell (6.0.44) unstable; urgency=medium
 
   * Sync: from linuxdeepin/dde-session-shell


### PR DESCRIPTION
as title

Log: as title

## Summary by Sourcery

Chores:
- Update Debian changelog to version 6.0.45