### PR TITLE
chore: bump version to 6.0.47

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+dde-session-shell (6.0.47) unstable; urgency=medium
+
+  * sync: from linuxdeepin/dde-session-shell (#461)
+  * sync: from linuxdeepin/dde-session-shell (#459)
+  * sync: from linuxdeepin/dde-session-shell
+  * sync: from linuxdeepin/dde-session-shell
+  * sync: from linuxdeepin/dde-session-shell (#456)
+  * sync: from linuxdeepin/dde-session-shell
+
+ -- Wang Zichong <wangzichong@deepin.org>  Fri, 12 Sep 2025 14:01:07 +0800
+
 dde-session-shell (6.0.46) unstable; urgency=medium
 
   * Sync: from linuxdeepin/dde-session-shell


### PR DESCRIPTION
update changelog to 6.0.47

## Summary by Sourcery

Chores:
- Update debian/changelog entry to reflect version 6.0.47