### PR TITLE
chore: bump version to 6.0.48

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+dde-session-shell (6.0.48) unstable; urgency=medium
+
+  * chore: remove unused Spanish translation files
+  * sync: from linuxdeepin/dde-session-shell
+  * sync: from linuxdeepin/dde-session-shell
+  * sync: from linuxdeepin/dde-session-shell
+  * sync: from linuxdeepin/dde-session-shell
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Thu, 18 Sep 2025 21:01:20 +0800
+
 dde-session-shell (6.0.47) unstable; urgency=medium
 
   * sync: from linuxdeepin/dde-session-shell (#461)


### PR DESCRIPTION
update changelog to 6.0.48

## Summary by Sourcery

Chores:
- Bump the Debian changelog entry to version 6.0.48