### PR TITLE
chore: bump version to 6.0.50

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-session-shell (6.0.50) unstable; urgency=medium
+
+  * sync: from linuxdeepin/dde-session-shell
+
+ -- caixiangrong <caixiangrong@uniontech.com>  Thu, 06 Nov 2025 16:35:16 +0800
+
 dde-session-shell (6.0.49) unstable; urgency=medium
 
   * sync: from linuxdeepin/dde-session-shell


### PR DESCRIPTION
update changelog to 6.0.50

## Summary by Sourcery

Chores:
- Update debian/changelog to reflect new version 6.0.50