### PR TITLE
feat: add reproducible build parameters

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -9,6 +9,9 @@ export DEB_CFLAGS_MAINT_APPEND = -Wall
 export DEB_CXXFLAGS_MAINT_APPEND = -Wall
 export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack -Wl,-E
 
+# reproducible编译参数
+DEB_CMAKE_EXTRA_FLAGS += -DCMAKE_SKIP_BUILD_RPATH=ON
+
 include /usr/share/dpkg/default.mk
 SYSTYPE=Desktop
 SYSTYPE=$(shell cat /etc/deepin-version | grep Type= | awk -F'=' '{print $$2}')
@@ -17,20 +20,21 @@ SYSTYPE=$(shell cat /etc/deepin-version | grep Type= | awk -F'=' '{print $$2}')
 
 ifeq ($(DEB_BUILD_ARCH), mipsel)
 override_dh_auto_configure:
-	dh_auto_configure -- LOCK_NO_QUIT=YES DISABLE_DEMO_VIDEO=YES DISABLE_TEXT_SHADOW=YES DISABLE_ANIMATIONS=YES USE_CURSOR_LOADING_ANI=YES
+	dh_auto_configure -- $(DEB_CMAKE_EXTRA_FLAGS) LOCK_NO_QUIT=YES DISABLE_DEMO_VIDEO=YES DISABLE_TEXT_SHADOW=YES DISABLE_ANIMATIONS=YES USE_CURSOR_LOADING_ANI=YES
 endif
 
 ifeq ($(DEB_BUILD_ARCH), mips64el)
 override_dh_auto_configure:
-	dh_auto_configure -- LOCK_NO_QUIT=YES DISABLE_DEMO_VIDEO=YES DISABLE_TEXT_SHADOW=YES DISABLE_ANIMATIONS=YES USE_CURSOR_LOADING_ANI=YES
+	dh_auto_configure -- $(DEB_CMAKE_EXTRA_FLAGS) LOCK_NO_QUIT=YES DISABLE_DEMO_VIDEO=YES DISABLE_TEXT_SHADOW=YES DISABLE_ANIMATIONS=YES USE_CURSOR_LOADING_ANI=YES
 endif
 
 ifeq ($(DEB_BUILD_ARCH), sw_64)
 override_dh_auto_configure:
-	dh_auto_configure -- LOCK_NO_QUIT=YES DISABLE_DEMO_VIDEO=YES DISABLE_TEXT_SHADOW=YES DISABLE_ANIMATIONS=YES USE_CURSOR_LOADING_ANI=YES
+	dh_auto_configure -- $(DEB_CMAKE_EXTRA_FLAGS) LOCK_NO_QUIT=YES DISABLE_DEMO_VIDEO=YES DISABLE_TEXT_SHADOW=YES DISABLE_ANIMATIONS=YES USE_CURSOR_LOADING_ANI=YES
 endif
 
 override_dh_auto_configure:
 	dh_auto_configure -- \
+		$(DEB_CMAKE_EXTRA_FLAGS) \
 		-DWAIT_DEEPIN_ACCOUNTS_SERVICE=1 \
 		-DDDE_SESSION_SHELL_SNIPE=1


### PR DESCRIPTION
Added CMAKE_SKIP_BUILD_RPATH flag to enable reproducible builds across different build environments. This flag prevents CMake from embedding build-specific RPATH information into binaries, ensuring that the same source code produces identical binary outputs regardless of the build directory or environment.

The DEB_CMAKE_EXTRA_FLAGS variable is now included in all dh_auto_configure calls for mipsel, mips64el, sw_64 architectures and the default configuration. This ensures consistent application of reproducible build settings across all supported architectures.

Log: Added reproducible build support for consistent binary generation

Influence:
1. Verify that builds produce identical binaries when built from different directories
2. Test package installation and runtime behavior on supported architectures
3. Confirm that RPATH information is not embedded in compiled binaries
4. Validate build process on mipsel, mips64el, and sw_64 architectures
5. Check that existing functionality remains unchanged with new build parameters

feat: 添加可重复编译参数

添加 CMAKE_SKIP_BUILD_RPATH 标志以实现跨不同构建环境的可重复编译。该标志
防止 CMake 将构建特定的 RPATH 信息嵌入到二进制文件中，确保无论构建目录或
环境如何，相同的源代码都能产生相同的二进制输出。

现在在所有 dh_auto_configure 调用中包含了 DEB_CMAKE_EXTRA_FLAGS 变量，适 用于 mipsel、mips64el、sw_64 架构和默认配置。这确保在所有支持的架构上一
致应用可重复构建设置。

Log: 新增可重复构建支持，确保一致的二进制文件生成

Influence:
1. 验证从不同目录构建时是否产生相同的二进制文件
2. 在支持的架构上测试软件包安装和运行时行为
3. 确认编译后的二进制文件中未嵌入 RPATH 信息
4. 在 mipsel、mips64el 和 sw_64 架构上验证构建过程
5. 检查现有功能在使用新构建参数后是否保持不变

## Summary by Sourcery

Enable reproducible builds by preventing CMake from embedding build-specific RPATH and propagating extra flags in Debian packaging scripts

Build:
- Add CMAKE_SKIP_BUILD_RPATH flag in debian/rules to avoid embedding build-specific RPATH information
- Include DEB_CMAKE_EXTRA_FLAGS in all dh_auto_configure calls for mipsel, mips64el, sw_64, and default configurations