### PR TITLE
chore: bump version to 6.0.51

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+dde-session-shell (6.0.51) unstable; urgency=medium
+
+  * sync: from linuxdeepin/dde-session-shell
+  * sync: from linuxdeepin/dde-session-shell
+  * sync: from linuxdeepin/dde-session-shell
+  * feat: add reproducible build parameters
+
+ -- zhaoyingzhen <zhaoyingzhen@uniontech.com>  Thu, 27 Nov 2025 17:34:37 +0800
+
 dde-session-shell (6.0.50) unstable; urgency=medium
 
   * sync: from linuxdeepin/dde-session-shell


### PR DESCRIPTION
update changelog to 6.0.51

## Summary by Sourcery

Chores:
- Refresh Debian changelog entry to reflect version 6.0.51.