### PR TITLE
chore: update changelog to 6.0.53

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+dde-session-shell (6.0.53) unstable; urgency=medium
+
+  * sync: from linuxdeepin/dde-session-shell
+  * sync: from linuxdeepin/dde-session-shell
+  * sync: from linuxdeepin/dde-session-shell
+
+ -- zhangkun <zhangkun2@uniontech.com>  Fri, 27 Feb 2026 17:03:15 +0800
+
 dde-session-shell (6.0.52) unstable; urgency=medium
 
   * Release 6.0.52


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 6.0.53

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 6.0.53
- 目标分支: master
