### PR TITLE
chore: update changelog to 6.0.54

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-session-shell (6.0.54) unstable; urgency=medium
+
+  * sync: from linuxdeepin/dde-session-shell
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 12 Mar 2026 21:22:15 +0800
+
 dde-session-shell (6.0.53) unstable; urgency=medium
 
   * sync: from linuxdeepin/dde-session-shell


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 6.0.54

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 6.0.54
- 目标分支: master

## Summary by Sourcery

Documentation:
- Refresh Debian changelog entries to document the 6.0.54 release.