### PR TITLE
chore: update changelog to 6.0.55

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-session-shell (6.0.55) unstable; urgency=medium
+
+  * sync: from linuxdeepin/dde-session-shell
+  * sync: from linuxdeepin/dde-session-shell
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 26 Mar 2026 19:40:05 +0800
+
 dde-session-shell (6.0.54) unstable; urgency=medium
 
   * sync: from linuxdeepin/dde-session-shell


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 6.0.55

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 6.0.55
- 目标分支: master

## Summary by Sourcery

Chores:
- Bump Debian changelog entry to version 6.0.55 targeting the master branch.