### PR TITLE
chore: update changelog to 6.0.59

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-session-shell (6.0.59) unstable; urgency=medium
+
+  * sync: from linuxdeepin/dde-session-shell
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 14 May 2026 22:11:09 +0800
+
 dde-session-shell (6.0.58) unstable; urgency=medium
 
   * sync: from linuxdeepin/dde-session-shell


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 6.0.59

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 6.0.59
- 目标分支: master

## Summary by Sourcery

Chores:
- Refresh debian/changelog entries to reflect version 6.0.59 targeting master.