### PR TITLE
chore: bump version to 6.0.61

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-session-shell-snipe (6.0.61) unstable; urgency=medium
+
+  * Release 6.0.61
+
+ -- xionglinlin <xionglinlin@uniontech.com>  Fri, 12 Jun 2026 11:43:49 +0800
+
 dde-session-shell (6.0.60) unstable; urgency=medium
 
   * sync: from linuxdeepin/dde-session-shell

--- a/debian/control
+++ b/debian/control
@@ -29,6 +29,7 @@ Package: dde-session-shell
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, ${dist:Depends},
  deepin-desktop-schemas (>=5.9.14),
+ deepin-security-loader,
  dde-daemon (>=6.1.26),
  x11-xserver-utils,
  deepin-authenticate(>=1.2.27),

--- a/debian/dde-session-shell.install
+++ b/debian/dde-session-shell.install
@@ -2,3 +2,4 @@ etc
 usr/bin
 usr/share
 usr/lib/*/security
+usr/libexec/deepin


### PR DESCRIPTION
update changelog to 6.0.61

Change-Id: I60e3dbd0f61da16c3e323c7a6d5ba742a545f396

## Summary by Sourcery

Chores:
- Update Debian changelog and control files to reflect version 6.0.61.