### PR TITLE
chore: update changelog to 6.0.62

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-session-shell (6.0.62) unstable; urgency=medium
+
+  * sync: from linuxdeepin/dde-session-shell
+
+ -- zhangkun <zhangkun2@uniontech.com>  Tue, 30 Jun 2026 17:34:58 +0800
+
 dde-session-shell (6.0.61) unstable; urgency=medium
 
   * Release 6.0.61


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 6.0.62

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 6.0.62
- 目标分支: master

## Summary by Sourcery

Chores:
- Bump Debian package changelog entry to version 6.0.62 targeting master.