### PR TITLE
fix: update dde-daemon dependency version constraint

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -30,7 +30,7 @@ Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, ${dist:Depends},
  deepin-desktop-schemas (>=5.9.14),
  deepin-security-loader,
- dde-daemon (>=6.1.26),
+ dde-daemon (>>6.1.99),
  x11-xserver-utils,
  deepin-authenticate(>=1.2.27),
  libssl3,


### PR DESCRIPTION
Changed the dependency version requirement for dde-daemon from ">=6.1.26" to ">>6.1.99" to ensure a strict minimum version of the package is enforced, preventing compatibility issues with older versions that may lack critical security features or API changes.

Influence:
1. Verify that installation succeeds with updated dde-daemon version
2. Test system behavior with version 6.1.99 or higher
3. Confirm that older versions are no longer accepted by the package manager
4. Check dependency resolution in offline installation scenarios

fix: 更新 dde-daemon 依赖版本约束

将 dde-daemon 的依赖版本要求从 ">=6.1.26" 改为 ">>6.1.99"，以确保强制 执行最低版本要求，防止因缺少关键安全特性或 API 变更的旧版本导致兼容性
问题。

Influence:
1. 验证在更新的 dde-daemon 版本下安装成功
2. 测试版本 6.1.99 及更高版本的系统行为
3. 确认包管理器不再接受旧版本
4. 检查离线安装场景中的依赖解析

PMS: BUG-367143
Change-Id: I249a7219a30f97dd529e9e08e1deae189312ffae

## Summary by Sourcery

Build:
- Update the dde-daemon version constraint in debian/control to enforce a stricter minimum supported version.