### PR TITLE
feat: add var/lib/dde-session-shell to package install list

### DIFF
--- a/debian/dde-session-shell.install
+++ b/debian/dde-session-shell.install
@@ -2,4 +2,5 @@ etc
 usr/bin
 usr/share
 usr/lib/*/security
+var/lib/dde-session-shell
 usr/libexec/deepin


### PR DESCRIPTION
debian/dde-session-shell.install 中新增 var/lib/dde-session-shell 路径， 使 dde-session-shell.conf 在 V25 打包时安装到 /var/lib/dde-session-shell/。

Log: 新增 /var/lib/dde-session-shell 打包路径
PMS: BUG-356947