### PR TITLE
chore: remove deprecated dde-network-dialog

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -38,8 +38,7 @@ Depends: ${shlibs:Depends}, ${misc:Depends}, ${dist:Depends},
  xsettingsd,
  onboard
 Provides: lightdm-greeter
-Recommends: dss-network-plugin,
- dde-network-dialog
+Recommends: dss-network-plugin
 Conflicts: dde-workspace,
  deepin-notifications,
  dde-session-ui (<< 5.0.0),


### PR DESCRIPTION
1. Remove dde-network-dialog from Recommends in debian/control
2. The package is deprecated and no longer needed as a recommended dependency

chore: 移除已弃用的 dde-network-dialog

1. 从 debian/control 的 Recommends 中移除 dde-network-dialog
2. 该包已弃用，不再需要作为推荐依赖

## Summary by Sourcery

Remove the deprecated dde-network-dialog package from Debian packaging metadata.

Build:
- Drop dde-network-dialog from the Recommends list in debian/control as it is deprecated.

Chores:
- Clean up packaging dependencies by removing an obsolete recommended package.