### PR TITLE
fix: delay authentication creation after system wake

### DIFF
--- a/src/dde-lock/lockworker.cpp
+++ b/src/dde-lock/lockworker.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -41,6 +41,7 @@ LockWorker::LockWorker(SessionBaseModel *const model, QObject *parent)
     , m_hotZoneInter(new DBusHotzone(DSS_DBUS::zoneService, DSS_DBUS::zonePath, QDBusConnection::sessionBus(), this))
     , m_resetSessionTimer(new QTimer(this))
     , m_limitsUpdateTimer(new QTimer(this))
+    , m_wakeUpAuthTimer(new QTimer(this))
     , m_sessionManagerInter(new SessionManagerInter(DSS_DBUS::sessionManagerService, DSS_DBUS::sessionManagerPath, QDBusConnection::sessionBus(), this))
     , m_switchosInterface(new HuaWeiSwitchOSInterface("com.huawei", "/com/huawei/switchos", QDBusConnection::sessionBus(), this))
     , m_kglobalaccelInter(nullptr)
@@ -54,6 +55,12 @@ LockWorker::LockWorker(SessionBaseModel *const model, QObject *parent)
     m_limitsUpdateTimer->setInterval(50);
 
     m_resetSessionTimer->setInterval(15000);
+
+    m_wakeUpAuthTimer->setSingleShot(true);
+    m_wakeUpAuthTimer->setInterval(300);
+    connect(m_wakeUpAuthTimer, &QTimer::timeout, this, [this](){
+        createAuthentication(m_model->currentUser()->name());
+    });
 
 #ifndef ENABLE_DSS_SNIPE
     if (m_gsettings != nullptr && m_gsettings->keys().contains("authResetTime")){
@@ -147,8 +154,9 @@ void LockWorker::initConnections()
         }
 
         if (active && m_model->visible()) {
-            createAuthentication(m_model->currentUser()->name());
+            m_wakeUpAuthTimer->start();
         } else {
+            m_wakeUpAuthTimer->stop();
             endAuthentication(m_account, AT_All);
             destroyAuthentication(m_account);
         }
@@ -193,6 +201,7 @@ void LockWorker::initConnections()
 
         if (isSleep) {
             checkSystemWakeupTimer->start();
+            m_wakeUpAuthTimer->stop();
             doSuspendTime = QDateTime::currentDateTime();
             m_model->setIsBlackMode(true);
             // 休眠时按需拉起锁屏,注意此时是被动响应休眠
@@ -211,11 +220,12 @@ void LockWorker::initConnections()
                 if (m_login1SessionSelf->active()) {
                     endAuthentication(m_account, AT_All);
                     destroyAuthentication(m_account);
-                    createAuthentication(m_model->currentUser()->name());
+                    m_wakeUpAuthTimer->start();
                 }
             } else {
                 // 处理其他流程设置的可见状态
                 m_model->setVisible(false);
+                m_wakeUpAuthTimer->stop();
             }
             // 避免在电源选项处理中设置密码模式，会导致唤醒后闪锁屏
             m_model->setCurrentModeState(SessionBaseModel::ModeStatus::PasswordMode);

--- a/src/dde-lock/lockworker.h
+++ b/src/dde-lock/lockworker.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -92,6 +92,7 @@ private:
     DBusHotzone *m_hotZoneInter;
     QTimer *m_resetSessionTimer;
     QTimer *m_limitsUpdateTimer;
+    QTimer *m_wakeUpAuthTimer;
     QString m_password;
     QMap<std::shared_ptr<User>, bool> m_lockUser;
     SessionManagerInter *m_sessionManagerInter;


### PR DESCRIPTION
1. Add a dedicated `m_wakeUpAuthTimer` (300ms single-shot) to postpone authentication creation after system wake-up
2. Replace direct `createAuthentication()` calls in system wake and active change flows with timer-triggered execution
3. Stop timer appropriately during sleep, invisible, or inactive states to prevent unnecessary authentication
4. Fix potential race condition where authentication creation during screen wake could be interrupted by system events

Log: Fix potential lock screen flash or authentication failure after system wake-up

Influence:
1. Test system wake-up from sleep and verify lock screen appears normally without flashing
2. Test rapid wake-sleep-wake cycles to ensure authentication state is consistent
3. Test when lock screen is invisible during wake-up to verify no authentication is created
4. Test switching user accounts after wake-up to verify authentication creation is correct
5. Test system suspend/resume multiple times to check stability
6. Verify no authentication is triggered when system enters sleep or becomes inactive

fix: 延迟系统唤醒后的认证创建

1. 添加专用的 `m_wakeUpAuthTimer`（300ms 单次触发）来延迟系统唤醒后的认 证创建
2. 将系统唤醒和活动状态变化流程中的直接 `createAuthentication()` 调用替 换为定时器触发执行
3. 在休眠、不可见或不活动状态时适当停止定时器，避免不必要的认证
4. 修复屏幕唤醒期间认证创建可能被系统事件打断的竞态条件问题

Log: 修复系统唤醒后可能出现的锁屏闪烁或认证失败问题

Influence:
1. 测试系统从休眠唤醒后锁屏是否正常显示，无闪烁现象
2. 测试快速唤醒-休眠-唤醒循环，验证认证状态一致性
3. 测试唤醒时锁屏不可见的情况，验证不会创建认证
4. 测试唤醒后切换用户账户，验证认证创建正确性
5. 多次测试系统挂起/恢复，检查稳定性
6. 验证系统进入休眠或不活动状态时不会触发认证

PMS: BUG-373405

## Summary by Sourcery

Delay post-wake authentication creation and cancel it when the lock screen is not eligible, preventing wake-up race conditions and unnecessary authentication.

Bug Fixes:
- Prevent authentication failures and lock-screen flashing after system wake-up by delaying authentication creation until the system state stabilizes.
- Avoid creating authentication while the system is sleeping, inactive, or the lock screen is not visible.

Enhancements:
- Coordinate authentication creation across wake-up and active-state transitions to improve consistency during suspend/resume and rapid power-state changes.